### PR TITLE
[fix] ProfileView에서 다이버 기록 컴포넌트, 버튼 색상 -> DiveColor에 정의된 색상으로 수정

### DIFF
--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/ProfileScene/View/ProfileView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/ProfileScene/View/ProfileView.swift
@@ -55,7 +55,7 @@ struct ProfileView: View {
                 VStack(spacing: 14){
                     HStack{
                         Text("다이버에 대한 기록을 남겨주세요!")
-                            .foregroundStyle(Color.gray3)
+                            .foregroundStyle(DiveColor.color2)
                         Spacer()
                     }
                     
@@ -68,7 +68,7 @@ struct ProfileView: View {
                 
                 //MARK: Module 4 : 저장버튼
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(Color.savebutton)
+                    .fill(DiveColor.color4)
                     .frame(height: 55)
                     .frame(maxWidth: .infinity)
                     .overlay(


### PR DESCRIPTION
기존의 Color.gray3, Color.savebutton 이 없는 색상으로 에러가 발생하여 DiveColor 에 정의된 색상으로 수정하였습니다.

## 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 

기존의 Color.gray3, Color.savebutton 이 없는 색상으로 에러가 발생하여 DiveColor 에 정의된 색상으로 수정하였습니다.

## 📌 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 

Color는 DiveColor 에 정의된 색상을, Font는 DiveFont 에 정의된 폰트를 따르도록 작성해주시면 감사하겠습니다.
각 뷰의 Color, Font 관련 정보는 Figma 에 나와있습니다.
