### PR TITLE
[feat] 다이버 탐색 및 발견 구현

### DIFF
--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/Coordinator.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/Coordinator.swift
@@ -28,4 +28,6 @@ enum Path: Hashable {
     case userProfileSetting(nickname: String)
     case idCardScan
     case mainTab
+    case searchingDiver
+    case searchResult(nickname: String)
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -26,6 +26,11 @@ struct DiverBookIOSApp: App {
                             case .mainTab:
                                 DiverBookTabView(coordinator: self.coordinator)
                                     .toolbar(.hidden, for: .navigationBar)
+                            case .searchingDiver:
+                                DiverSearchingView(coordinator: self.coordinator)
+                                    .toolbar(.hidden, for: .navigationBar)
+                            case .searchResult(nickname: let nickname):
+                                DiverSearchResultView(nickname: nickname)
                             }
                         })
             }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Global/UIKitWrappers/LottieView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Global/UIKitWrappers/LottieView.swift
@@ -1,0 +1,27 @@
+//
+//  LottieView.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 4/20/25.
+//
+
+import Lottie
+import SwiftUI
+
+struct LottieView: UIViewRepresentable {
+    var animationName: String
+    var shouldPlay: Bool
+
+    func makeUIView(context: Context) -> some UIView {
+        let animationView = LottieAnimationView(name: animationName)
+        animationView.loopMode = .loop
+        if shouldPlay {
+            animationView.play()
+        }
+        return animationView
+    }
+
+    func updateUIView(_ uiView: UIViewType, context: Context) {
+        // 필요 시점에 작성
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Global/Utils/UUIDManager.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Global/Utils/UUIDManager.swift
@@ -1,0 +1,25 @@
+//
+//  UUIDManager.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 4/21/25.
+//
+
+import Foundation
+
+class UUIDManager {
+    static let shared = UUIDManager()
+    
+    private let key = "deviceUUID"
+    private init() {}
+    
+    var uuid: String {
+        if let saved = UserDefaults.standard.string(forKey: key) {
+            return saved
+        } else {
+            let newUUID = UUID().uuidString
+            UserDefaults.standard.set(newUUID, forKey: key)
+            return newUUID
+        }
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/View/DiverSearchResultView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/View/DiverSearchResultView.swift
@@ -1,0 +1,39 @@
+//
+//  DiverSearchResultView.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 4/21/25.
+//
+
+import SwiftUI
+
+struct DiverSearchResultView: View {
+    let nickname: String
+    
+    var body: some View {
+        VStack {
+            Spacer()
+            Group {
+                Text("심해를 탐험하는")
+                    .foregroundColor(DiveColor.gray4)
+                Text("\(nickname) ")
+                    .foregroundColor(DiveColor.color6)
+                + Text("발견!")
+                    .foregroundColor(DiveColor.gray4)
+            }
+            .font(DiveFont.headingH1)
+            
+            PrimaryProfile(image: Image("exMemoji"), style: .found)
+                .padding(.top, 20)
+            Spacer()
+            PrimaryButton(title: "대화 시작", coordinator: Coordinator()) {
+                // TODO: - 대화 시작으로 이동
+            }
+            .padding(.horizontal, 24)
+        }
+    }
+}
+
+#Preview {
+    DiverSearchResultView(nickname: "Berry")
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/View/DiverSearchingView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/View/DiverSearchingView.swift
@@ -1,0 +1,67 @@
+//
+//  DiverSearchingView.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 4/20/25.
+//
+
+import SwiftUI
+
+struct DiverSearchingView: View {
+    @StateObject var viewModel: DiverSearchingViewModel
+    @StateObject private var dataTransferManager: DataTransferManager
+    
+    private let advertiseManager: AdvertiserManager
+    private let browseManager: BrowserManager
+    
+    init(coordinator: Coordinator) {
+        let viewModel = DiverSearchingViewModel(coordinator: coordinator)
+        _viewModel = StateObject(wrappedValue: viewModel)
+        let nickname = "Berry"
+        let manager = DataTransferManager(nickname: nickname, viewModel: viewModel)
+        self._dataTransferManager = StateObject(wrappedValue: manager)
+        self.advertiseManager = AdvertiserManager(dataTransferManager: manager)
+        self.browseManager = BrowserManager(dataTransferManager: manager)
+    }
+    
+    @Environment(\.dismiss) var dismiss
+    
+    var body: some View {
+        VStack(spacing: 10) {
+            TopBar()
+            Spacer()
+            LottieView(animationName: "DiverDrop", shouldPlay: true)
+                .frame(width: 350, height: 100)
+                .padding(.bottom, 40)
+            Text("만나는 다이버에게 이렇게 질문해보세요")
+                .font(DiveFont.bodyMedium1)
+                .foregroundColor(DiveColor.gray4)
+            Group {
+                Text("“같이 ")
+                    .foregroundColor(DiveColor.gray4)
+                + Text("다이빙 ")
+                    .foregroundColor(DiveColor.color6)
+                + Text("하실래요?”")
+                    .foregroundColor(DiveColor.gray4)
+            }
+            .font(DiveFont.headingH2)
+            
+            HStack(spacing: 5) {
+                ProgressView()
+                Text("탐색중...")
+                    .font(DiveFont.bodyMedium2)
+                    .foregroundColor(DiveColor.gray3)
+            }
+            .padding(.top, 100)
+            
+            Spacer()
+        }
+        .padding(.horizontal, 24)
+        .onAppear {
+            dataTransferManager.startSession()
+        }
+        .onDisappear {
+            dataTransferManager.stopSession()
+        }
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/ViewModel/DiverSearchResultViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/ViewModel/DiverSearchResultViewModel.swift
@@ -1,0 +1,27 @@
+//
+//  DiverSearchResultViewModel.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 4/22/25.
+//
+
+import Combine
+import SwiftUI
+
+final class DiverSearchResultViewModel: ViewModelable {
+    struct State {
+    }
+    
+    enum Action {
+    }
+    
+    @Published var state: State = State()
+    @ObservedObject var coordinator: Coordinator
+    
+    init(coordinator: Coordinator) {
+        self.coordinator = coordinator
+    }
+    
+    func action(_ action: Action) {
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/ViewModel/DiverSearchingViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/ViewModel/DiverSearchingViewModel.swift
@@ -1,0 +1,32 @@
+//
+//  DiverSearchingViewModel.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 4/20/25.
+//
+
+import Combine
+import SwiftUI
+
+final class DiverSearchingViewModel: ViewModelable {
+    struct State {
+    }
+    
+    enum Action {
+        case successSearchingDiver(nickname: String)
+    }
+    
+    @Published var state: State = State()
+    @ObservedObject var coordinator: Coordinator
+    
+    init(coordinator: Coordinator) {
+        self.coordinator = coordinator
+    }
+    
+    func action(_ action: Action) {
+        switch action {
+        case .successSearchingDiver(let nickname):
+            self.coordinator.push(.searchResult(nickname: nickname))
+        }
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/IDCardScannerScene/View/SubView/DiverTopBar.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/IDCardScannerScene/View/SubView/DiverTopBar.swift
@@ -19,6 +19,7 @@ struct TopBar: View {
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 12)
+                    .foregroundColor(DiveColor.color6)
             })
             .buttonStyle(.plain)
             Spacer()

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Service/Connectivity/AdvertiserManager.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Service/Connectivity/AdvertiserManager.swift
@@ -1,0 +1,44 @@
+//
+//  AdvertiserManager.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 4/21/25.
+//
+
+import MultipeerConnectivity
+
+final class AdvertiserManager: NSObject, MCNearbyServiceAdvertiserDelegate {
+    private let dataTransferManager: DataTransferManager
+    private let peerID = MCPeerID(displayName: UIDevice.current.name)
+    private var advertiser: MCNearbyServiceAdvertiser?
+
+    init(dataTransferManager: DataTransferManager) {
+        self.dataTransferManager = dataTransferManager
+        super.init()
+        advertiser = MCNearbyServiceAdvertiser(
+            peer: dataTransferManager.peerID,
+            discoveryInfo: ["uuid": UUIDManager.shared.uuid],
+            serviceType: "DiverBook"
+        )
+        advertiser?.delegate = self
+    }
+
+    func start() {
+        advertiser?.stopAdvertisingPeer()
+        advertiser?.startAdvertisingPeer()
+        print("start advertising")
+    }
+
+    func endSession() {
+        advertiser?.stopAdvertisingPeer()
+    }
+    
+    func advertiser(_ advertiser: MCNearbyServiceAdvertiser,
+                    didReceiveInvitationFromPeer peerID: MCPeerID,
+                    withContext context: Data?,
+                    invitationHandler: @escaping (Bool, MCSession?) -> Void
+    ) {
+        print("📩 초대 수신 : \(peerID.displayName)")
+        invitationHandler(true, dataTransferManager.session)
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Service/Connectivity/BrowserManager.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Service/Connectivity/BrowserManager.swift
@@ -1,0 +1,45 @@
+//
+//  BrowserManager.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 4/21/25.
+//
+
+import MultipeerConnectivity
+
+final class BrowserManager: NSObject, MCNearbyServiceBrowserDelegate {
+    private let dataTransferManager: DataTransferManager
+    private var browser: MCNearbyServiceBrowser?
+    private let myUUID = UUIDManager.shared.uuid
+
+    init(dataTransferManager: DataTransferManager) {
+        self.dataTransferManager = dataTransferManager
+        super.init()
+        browser = MCNearbyServiceBrowser(peer: dataTransferManager.peerID, serviceType: "DiverBook")
+        browser?.delegate = self
+    }
+
+    func start() {
+        browser?.stopBrowsingForPeers()
+        browser?.startBrowsingForPeers()
+        print("start browsing")
+    }
+    
+    func endSession() {
+        browser?.stopBrowsingForPeers()
+    }
+    
+    func browser(_: MCNearbyServiceBrowser,
+                 foundPeer peerID: MCPeerID,
+                 withDiscoveryInfo info: [String : String]?
+    ) {
+        guard let peerUUID = info?["uuid"] else { return }
+        
+        if myUUID < peerUUID {
+            browser?.invitePeer(peerID, to: dataTransferManager.session, withContext: nil, timeout: 10)
+            print("invitePeer")
+        }
+    }
+
+    func browser(_: MCNearbyServiceBrowser, lostPeer _: MCPeerID) {}
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Service/Connectivity/DataTransferManager.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Service/Connectivity/DataTransferManager.swift
@@ -1,0 +1,151 @@
+//
+//  DataTransferManager.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 4/21/25.
+//
+
+import Foundation
+import NearbyInteraction
+import MultipeerConnectivity
+
+final class DataTransferManager: NSObject, ObservableObject {
+    private let serviceType = "DiverBook"
+    var peerID: MCPeerID!
+    var session: MCSession!
+    private var niSession: NISession?
+    private var nearbyToken: NIDiscoveryToken?
+    private var advertiserManager: AdvertiserManager?
+    private var browserManager: BrowserManager?
+    weak var viewModel: DiverSearchingViewModel?
+    @Published var isBrowser: Bool = false
+    
+    private let minDistance: Float = 0.2
+    private let maxDistance: Float = 0.3
+
+    // TODO: - 내 실제 닉네임 전달해주도록 변경
+    @Published var myNickname: String = "User\(Int.random(in: 1000...9999))"
+    @Published var receivedNickname: String = ""
+
+    init(nickname: String, viewModel: DiverSearchingViewModel) {
+        self.myNickname = nickname
+        self.viewModel = viewModel
+        self.peerID = MCPeerID(displayName: UIDevice.current.name)
+        self.session = MCSession(
+            peer: peerID,
+            securityIdentity: nil,
+            encryptionPreference: .required
+        )
+        super.init()
+        advertiserManager = AdvertiserManager(dataTransferManager: self)
+        browserManager = BrowserManager(dataTransferManager: self)
+        session.delegate = self
+        
+        setupNISession()
+    }
+
+    func startSession() {
+        advertiserManager?.start()
+        print("🔊 광고 시작됨")
+        browserManager?.start()
+        print("🔍 브라우징 시작됨")
+    }
+    
+    func stopSession() {
+        advertiserManager?.endSession()
+        browserManager?.endSession()
+        niSession?.invalidate()
+        session.disconnect()
+    }
+    
+    private func setupNISession() {
+        print("setupNISession")
+        niSession = NISession()
+        niSession?.delegate = self
+    }
+    
+    private func runNISession(with token: NIDiscoveryToken) {
+        print("runNISession")
+        let config = NINearbyPeerConfiguration(peerToken: token)
+        niSession?.run(config)
+    }
+    
+    private func sendNicknameIfWithinRange(distance: Float) {
+        print("sendNicknameIfWithinRange")
+        if distance >= minDistance && distance <= maxDistance {
+            sendNickname()
+            niSession?.invalidate()
+        }
+    }
+    
+    private func sendNickname() {
+        print("sendNickname")
+        guard !session.connectedPeers.isEmpty else { return }
+        if let data = myNickname.data(using: .utf8) {
+            try? session.send(data, toPeers: session.connectedPeers, with: .reliable)
+        }
+    }
+}
+
+// MARK: - MCSessionDelegate
+extension DataTransferManager: MCSessionDelegate {
+    func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
+        if state == .connected {
+            if let token = niSession?.discoveryToken {
+                if let data = try? NSKeyedArchiver.archivedData(
+                    withRootObject: token,
+                    requiringSecureCoding: true
+                ) {
+                    try? session.send(data, toPeers: [peerID], with: .reliable)
+                }
+                return
+            }
+        }
+    }
+
+    func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
+        if let object = try? NSKeyedUnarchiver.unarchivedObject(
+            ofClass: NIDiscoveryToken.self,
+            from: data
+        ) {
+            DispatchQueue.main.async {
+                self.nearbyToken = object
+                self.runNISession(with: object)
+            }
+            return
+        }
+
+        // 닉네임 수신 처리
+        if let nickname = String(data: data, encoding: .utf8) {
+            DispatchQueue.main.async {
+                self.receivedNickname = nickname
+                self.viewModel?.action(.successSearchingDiver(nickname: nickname))
+                print("📥 받은 닉네임: \(nickname)")
+            }
+        }
+    }
+
+    func session(_: MCSession, didReceive _: InputStream, withName _: String, fromPeer _: MCPeerID) {}
+    func session(_: MCSession, didStartReceivingResourceWithName _: String, fromPeer _: MCPeerID, with _: Progress) {}
+    func session(_: MCSession, didFinishReceivingResourceWithName _: String, fromPeer _: MCPeerID, at _: URL?, withError _: Error?) {}
+}
+
+// MARK: - NearbyInteraction Delegate
+extension DataTransferManager: NISessionDelegate {
+    func session(_ session: NISession, didUpdate nearbyObjects: [NINearbyObject]) {
+        guard let object = nearbyObjects.first, let distance = object.distance else { return }
+
+        print("기기 간 거리: \(distance)m")
+
+        sendNicknameIfWithinRange(distance: distance)
+    }
+
+    func sessionWasSuspended(_ session: NISession) {
+        session.run(session.configuration!)
+    }
+
+    func session(_ session: NISession, didInvalidateWith error: Error) {
+        print("❌ NI 세션 종료: \(error.localizedDescription)")
+        niSession = nil
+    }
+}

--- a/DiverBook_iOS/Project.swift
+++ b/DiverBook_iOS/Project.swift
@@ -41,7 +41,7 @@ let project = Project(
                 )
             ],
             dependencies: [
-                
+                .external(name: "Lottie")
             ],
             additionalFiles: [".swiftlint.yml"]
         ),

--- a/DiverBook_iOS/Tuist/Package.resolved
+++ b/DiverBook_iOS/Tuist/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "e11cc5f056f8dbd923804f294297b36a744ab8a2e61ce65940fdd3ed6994c822",
+  "pins" : [
+    {
+      "identity" : "lottie-spm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/airbnb/lottie-spm.git",
+      "state" : {
+        "revision" : "8c6edf4f0fa84fe9c058600a4295eb0c01661c69",
+        "version" : "4.5.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/DiverBook_iOS/Tuist/Package.swift
+++ b/DiverBook_iOS/Tuist/Package.swift
@@ -8,7 +8,7 @@ import PackageDescription
         // Customize the product types for specific package product
         // Default is .staticFramework
         // productTypes: ["Alamofire": .framework,]
-        productTypes: [:]
+        productTypes: ["Lottie": .staticLibrary]
     )
 #endif
 
@@ -18,5 +18,6 @@ let package = Package(
         // Add your own dependencies here:
         // .package(url: "https://github.com/Alamofire/Alamofire", from: "5.0.0"),
         // You can read more about dependencies here: https://docs.tuist.io/documentation/tuist/dependencies
+        .package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.5.0")
     ]
 )


### PR DESCRIPTION
## 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] 다이버 탐색 화면
- [x] 다이버 탐색 결과 화면
- [x] 다이버 탐색 결과 기기 간 전달로 표시

## 📌 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
### 동작
아래 영상처럼 동작됩니다. 다른 두 기기가 탐색화면에 진입하면 세션이 시작되고, 이후 토큰을 주고 받아 (MultipeerConnectivity 이용) 기기 간 거리를 측정(NearbyInteraction 이용)합니다. 특정 거리 조건을 만족한다면, 서로 데이터를 교환합니다.
* 현재는 '탐색중' 프로그래스뷰도 추가되었습니다.

https://github.com/user-attachments/assets/66c3db93-0eac-4870-9a0e-2e3aa1ca2a96


### 세션 재시작
세션 시작이 화면 시작 시점에 발생됩니다.
일반적인 경우에는 잘 수행되지만, 확신할 수 없는 상황이 있습니다. 
한번 시도한 이후 다른 화면에서 다시 접근했을 경우 제대로 동작하지 않을 수 있습니다.
(앱 종료 후 다시 시도하면 무조건 성공, 하지만 그 외에는?)
홈 화면과 탐색 화면으로 완전 연결이 된 다음 확인해보고 추가 개선 하겠습니다!


### 추가
- Topbar 색상 파란색으로 맞춰달라고 하셔서 추가했습니다. 회원정보 입력시에도 파란색으로 통일되었습니다.

- 데이터를 교환받아 보여줄 때, 다른 인터랙션이 없다보니 살짝 심심한 느낌이 있습니다.
기능 구현이 다 끝나면 애니메이션 효과나 햅틱 적용해봐도 좋을 것 같습니다.
