### PR TITLE
[feat] Service Error 시점에 띄울 Alert(Banner) 구현

### DIFF
--- a/DiverBook_iOS/DiverBook_iOS/Sources/Common/DesignSystem/DiveFont.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Common/DesignSystem/DiveFont.swift
@@ -20,6 +20,8 @@ enum DiveFont {
     static let bodyMedium1: Font = .system(size: 16, weight: .regular)
     /// size: 14, weight: regular
     static let bodyMedium2: Font = .system(size: 14, weight: .regular)
+    /// size: 14, weight: semibold
+    static let bodySemibold: Font = .system(size: 14, weight: .semibold)
     /// size: 12, weight: regular
     static let bodyExtra1: Font = .system(size: 12, weight: .regular)
     /// size: 10, weight: regular

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Common/DesignSystem/DiveFont.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Common/DesignSystem/DiveFont.swift
@@ -30,4 +30,6 @@ enum DiveFont {
     static let bar: Font = .system(size: 18, weight: .medium)
     /// size: 18 , weight: semibold
     static let bodyPretendard: Font = .custom("Pretendard-SemiBold", size: 18)
+    /// size: 16, weight: semibold
+    static let bodyMediumPretendard: Font = .custom("Pretendard-SemiBold", size: 16)
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Common/DesignSystem/ServiceErrorAlert.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Common/DesignSystem/ServiceErrorAlert.swift
@@ -1,0 +1,50 @@
+//
+//  ServiceErrorAlert.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 4/27/25.
+//
+
+import SwiftUI
+
+struct ServiceErrorAlert: View {
+    let message: String
+    
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 10)
+                .foregroundColor(DiveColor.color1)
+            ServiceErrorContent(message: message)
+        }
+        .frame(width: 350, height: 55)
+    }
+}
+
+struct ServiceErrorContent: View {
+    let message: String
+    
+    var body: some View {
+        HStack(spacing: 15) {
+            RoundedCornerView(
+                radius: 10,
+                maskedCorners: [.layerMinXMinYCorner, .layerMinXMaxYCorner],
+                color: DiveColor.color2.opacity(0.4))
+                .frame(width: 10)
+            Image(systemName: "exclamationmark.circle.fill")
+                .foregroundColor(DiveColor.color6)
+                .font(.system(size: 26))
+            RoundedRectangle(cornerRadius: 10)
+                .frame(height: 26)
+                .frame(width: 1)
+                .foregroundColor(DiveColor.color2)
+            Text(message)
+                .foregroundColor(DiveColor.color6)
+                .font(DiveFont.bodyMediumPretendard)
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    ServiceErrorAlert(message: "Service unavailable")
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Common/DesignSystem/ServiceErrorAlert.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Common/DesignSystem/ServiceErrorAlert.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ServiceErrorAlert: View {
     let message: String
+    @Binding var showErrorAlert: Bool
     
     var body: some View {
         ZStack {
@@ -16,7 +17,12 @@ struct ServiceErrorAlert: View {
                 .foregroundColor(DiveColor.color1)
             ServiceErrorContent(message: message)
         }
-        .frame(width: 350, height: 55)
+        .frame(height: 55)
+        .padding(.top, 50)
+        .padding(.horizontal, 24)
+        .opacity(showErrorAlert ? 1 : 0)
+        .scaleEffect(showErrorAlert ? 1.0 : 0.8)
+        .animation(.easeInOut(duration: 0.4), value: showErrorAlert)
     }
 }
 
@@ -43,8 +49,4 @@ struct ServiceErrorContent: View {
             Spacer()
         }
     }
-}
-
-#Preview {
-    ServiceErrorAlert(message: "Service unavailable")
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Global/UIKitWrappers/RoundedCornerView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Global/UIKitWrappers/RoundedCornerView.swift
@@ -1,0 +1,28 @@
+//
+//  RoundedCorner.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 4/28/25.
+//
+import SwiftUI
+
+struct RoundedCornerView: UIViewRepresentable {
+    var radius: CGFloat
+    var maskedCorners: CACornerMask
+    var color: Color
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = UIColor(color)
+        view.layer.cornerRadius = radius
+        view.layer.maskedCorners = maskedCorners
+        view.layer.masksToBounds = true
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        uiView.layer.cornerRadius = radius
+        uiView.layer.maskedCorners = maskedCorners
+        uiView.backgroundColor = UIColor(color)
+    }
+}


### PR DESCRIPTION
## 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] ServiceErrorAlert 구현
- [x] DiveFont 추가

## 📌 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
### ServiceErrorAlert
아래와 같은 형태로 구현했습니다.
위치는 네비게이션 부분과 겹치지 않을 정도로 주었고, 자연스럽게 나타나고 4초 후 사라지도록 만들었습니다.

https://github.com/user-attachments/assets/6b2cd0bd-2d90-413e-aa5a-8eaa70afadfd

사용은 아래와 같이 가능합니다.
```swift
@State private var showErrorAlert = false

...

    ZStack(alignment: .top) {
        // 기존 뷰 (여기서 필요 시점에 showServiceErrorAlert() 호출)
        ServiceErrorAlert(message: "Service unavailable", showErrorAlert: $showErrorAlert)
    }

...

func showServiceErrorAlert() {
    showErrorAlert = true
    DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
        showErrorAlert = false
    }
}
```

### DiveFont

Ted가 이전에 네이밍 정해지면 추가하겠다고 하셨던 폰트 추가했습니다.
그리고 이전에 revert 하고 다시 올렸던 Font 저는 아직도 안보이는데,, 확인 부탁드립니다.
develop 브랜치에서도 아예 안보이는 것 같습니다.
다시 추가해 함께 올릴까하다 혹시 몰라 우선 제외하고 올립니다.
(그냥 다시 올려도 괜찮을 것 같으면 제가 해당 PR 머지 전에 추가하겠습니다.)

