### PR TITLE
네트워크 통신 구현 (Clean Architecture 적용)

### DIFF
--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/DiverBookAuthEndpoint.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/DiverBookAuthEndpoint.swift
@@ -1,0 +1,64 @@
+//
+//  DiverBookAuthEndpoint.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/28/25.
+//
+
+enum DiverBookAuthEndpoint: Endpoint {
+    case signUp(
+        userName: String,
+        divisions: String,
+        phoneNumber: String,
+        interests: String,
+        places: String,
+        about: String,
+        password: String
+    )
+    
+    var path: String {
+        switch self {
+        case .signUp:
+            return "/api/auth/signup"
+        }
+    }
+    
+    var method: RequestMethod {
+        switch self {
+        case .signUp:
+            return .post
+        }
+    }
+    
+    var query: [String: String]? {
+        switch self {
+        default:
+            return nil
+        }
+    }
+    
+    var header: [String: String]? {
+        switch self {
+        case .signUp:
+            return [
+                "accept": "*/*",
+                "Content-Type": "application/json"
+            ]
+        }
+    }
+    
+    var body: [String: String]? {
+        switch self {
+        case .signUp(let params):
+            return [
+                "userName": params.userName,
+                "divisions": params.divisions,
+                "phoneNumber": params.phoneNumber,
+                "interests": params.interests,
+                "places": params.places,
+                "about": params.about,
+                "password": params.password
+            ]
+        }
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/Endpoint.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/Endpoint.swift
@@ -1,0 +1,33 @@
+//
+//  EndPoint.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/28/25.
+//
+
+protocol Endpoint {
+    var scheme: String { get }
+    var host: String { get }
+    var path: String { get }
+    var method: RequestMethod { get }
+    var query: [String: String]? { get }
+    var header: [String: String]? { get }
+    var body: [String: String]? { get }
+}
+
+extension Endpoint {
+    var scheme: String {
+        return "https"
+    }
+    
+    var host: String {
+        return "diverbook.sijun.dev"
+    }
+}
+
+enum RequestMethod: String {
+    case get = "GET"
+    case post = "POST"
+    case delete = "DELETE"
+    case patch = "PATCH"
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/HTTPClient.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/HTTPClient.swift
@@ -1,0 +1,61 @@
+//
+//  HTTPClient.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/28/25.
+//
+import Foundation
+
+protocol HTTPClient {
+    func request<T: Decodable>(endpoint: Endpoint, responseModel: T.Type) async
+        -> Result<T, RequestError>
+}
+
+extension HTTPClient {
+    func request<T: Decodable>(
+        endpoint: Endpoint,
+        responseModel: T.Type
+    ) async -> Result<T, RequestError> {
+        var urlComponents = URLComponents()
+        urlComponents.scheme = endpoint.scheme
+        urlComponents.host = endpoint.host
+        urlComponents.path = endpoint.path
+        guard let url = urlComponents.url else {
+            return .failure(.invalidURL)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = endpoint.method.rawValue
+        request.allHTTPHeaderFields = endpoint.header
+
+        if let body = endpoint.body {
+            request.httpBody = try? JSONSerialization.data(
+                withJSONObject: body as [String: Any], options: [])
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(
+                for: request, delegate: nil)
+            guard let response = response as? HTTPURLResponse else {
+                return .failure(.decode)
+            }
+
+            switch response.statusCode {
+            case 200...299:
+                guard
+                    let decodeResponse = try? JSONDecoder().decode(
+                        responseModel, from: data)
+                else {
+                    return .failure(.decode)
+                }
+                return .success(decodeResponse)
+            case 401:
+                return .failure(.unauthorized)
+            default:
+                return .failure(.unexpectedStatusCode)
+            }
+        } catch {
+            return .failure(.unknown)
+        }
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/ResponseModels/SignUpResModel+Mapping.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/ResponseModels/SignUpResModel+Mapping.swift
@@ -1,0 +1,24 @@
+//
+//  SignUpResModel.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/28/25.
+//
+
+struct SignUpResModel: Decodable {
+    var id: String
+    var accessToken: String
+    var refreshToken: String
+    var tokenType: String
+}
+
+// MARK: - Mappings to Domain
+extension SignUpResModel {
+    func toDomain() -> AuthInfo {
+        return .init(
+            id: id,
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            tokenType: tokenType)
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/DiverBookAuthService.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/DiverBookAuthService.swift
@@ -1,0 +1,31 @@
+//
+//  DiverBookAuthService.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/28/25.
+//
+
+final class DiverBookAuthService: DiverBookAuthServicable {
+    func signUp(
+        userName: String,
+        divisions: String,
+        phoneNumber: String,
+        interests: String,
+        places: String,
+        about: String,
+        password: String
+    ) async -> Result<SignUpResModel, RequestError> {
+        return await request(
+            endpoint: DiverBookAuthEndpoint.signUp(
+                userName: userName,
+                divisions: divisions,
+                phoneNumber: phoneNumber,
+                interests: interests,
+                places: places,
+                about: about,
+                password: password
+            ),
+            responseModel: SignUpResModel.self)
+    }
+
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/DiverBookTokenService.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/DiverBookTokenService.swift
@@ -1,0 +1,15 @@
+//
+//  DiverBookTokenService.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/28/25.
+//
+
+final class DiverBookTokenService: DiverBookTokenServicable {
+    func saveTokens(authInfo: AuthInfo) {
+        UserToken.accessToken = authInfo.accessToken
+        UserToken.refreshToken = authInfo.refreshToken
+        UserToken.tokenType = authInfo.tokenType
+        UserToken.id = authInfo.id
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/DefaultAuthRepository.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/DefaultAuthRepository.swift
@@ -1,0 +1,48 @@
+//
+//  DefaultAuthRepository.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/28/25.
+//
+
+final class DefaultAuthRepository: AuthRepository {
+    private var authService: DiverBookAuthServicable
+    private var tokenService: DiverBookTokenServicable
+    
+    init(
+        authService: DiverBookAuthServicable,
+        tokenService: DiverBookTokenServicable
+    ) {
+        self.authService = authService
+        self.tokenService = tokenService
+    }
+    
+    func signUp(
+        userName: String,
+        divisions: String,
+        phoneNumber: String,
+        interests: String,
+        places: String,
+        about: String,
+        password: String
+    ) async -> Result<Bool, Error> {
+        let signUpResult = await authService.signUp(
+            userName: userName,
+            divisions: divisions,
+            phoneNumber: phoneNumber,
+            interests: interests,
+            places: places,
+            about: about,
+            password: password
+        )
+        
+        switch signUpResult {
+        case .success(let signUpResModel):
+            let authInfo = signUpResModel.toDomain()
+            tokenService.saveTokens(authInfo: authInfo)
+            return .success(true)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/DiverBookAuthServicable.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/DiverBookAuthServicable.swift
@@ -1,0 +1,18 @@
+//
+//  DiverBookAuthServicable.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/29/25.
+//
+
+protocol DiverBookAuthServicable: HTTPClient {
+    func signUp(
+        userName: String,
+        divisions: String,
+        phoneNumber: String,
+        interests: String,
+        places: String,
+        about: String,
+        password: String
+    ) async -> Result<SignUpResModel, RequestError>
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/DiverBookTokenServicable.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/DiverBookTokenServicable.swift
@@ -1,0 +1,10 @@
+//
+//  DiverBookTokenServicable.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/29/25.
+//
+
+protocol DiverBookTokenServicable {
+    func saveTokens(authInfo: AuthInfo)
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/UserDefaults/UserDefaultWrapper.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/UserDefaults/UserDefaultWrapper.swift
@@ -1,0 +1,30 @@
+//
+//  UserDefaultWrapper.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/28/25.
+//
+
+import Foundation
+
+@propertyWrapper
+struct UserDefault<T> {
+    private let key: String
+    private let defaultValue: T
+    private let userDefaults: UserDefaults
+    
+    init(key: String, defaultValue: T, userDefaults: UserDefaults = .standard) {
+        self.key = key
+        self.defaultValue = defaultValue
+        self.userDefaults = userDefaults
+    }
+    
+    var wrappedValue: T {
+        get {
+            return userDefaults.object(forKey: key) as? T ?? defaultValue
+        }
+        set {
+            userDefaults.set(newValue, forKey: key)
+        }
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/UserDefaults/UserToken.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/UserDefaults/UserToken.swift
@@ -1,0 +1,20 @@
+//
+//  UserToken.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/28/25.
+//
+
+struct UserToken {
+    @UserDefault(key: "accessToken", defaultValue: "")
+    static var accessToken: String
+    
+    @UserDefault(key: "refreshToken", defaultValue: "")
+    static var refreshToken: String
+    
+    @UserDefault(key: "tokenType", defaultValue: "")
+    static var tokenType: String
+    
+    @UserDefault(key: "id", defaultValue: "")
+    static var id: String
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Entities/AuthInfo.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Entities/AuthInfo.swift
@@ -1,0 +1,13 @@
+//
+//  AuthInfo.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/28/25.
+//
+
+struct AuthInfo {
+    var id: String
+    var accessToken: String
+    var refreshToken: String
+    var tokenType: String
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/AuthRepository.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/AuthRepository.swift
@@ -1,0 +1,18 @@
+//
+//  AuthRepository.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/28/25.
+//
+
+protocol AuthRepository {
+    func signUp(
+        userName: String,
+        divisions: String,
+        phoneNumber: String,
+        interests: String,
+        places: String,
+        about: String,
+        password: String
+    ) async -> Result<Bool, Error>
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/LoginUseCase/AuthUseCase.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/LoginUseCase/AuthUseCase.swift
@@ -1,0 +1,18 @@
+//
+//  AuthUseCase.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/28/25.
+//
+
+protocol AuthUseCase {
+    func executeSignUp(
+        userName: String,
+        divisions: String,
+        phoneNumber: String,
+        interests: String,
+        places: String,
+        about: String,
+        password: String
+    ) async -> Result<Bool, Error>
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/LoginUseCase/DefaultAuthUseCase.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/LoginUseCase/DefaultAuthUseCase.swift
@@ -1,0 +1,34 @@
+//
+//  DefaultAuthUseCase.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/28/25.
+//
+
+final class DefaultAuthUseCase: AuthUseCase {
+    private var authRepository: AuthRepository
+    
+    init(authRepository: AuthRepository) {
+        self.authRepository = authRepository
+    }
+    
+    func executeSignUp(
+        userName: String,
+        divisions: String,
+        phoneNumber: String,
+        interests: String,
+        places: String,
+        about: String,
+        password: String
+    ) async -> Result<Bool, Error> {
+        return await authRepository.signUp(
+            userName: userName,
+            divisions: divisions,
+            phoneNumber: phoneNumber,
+            interests: interests,
+            places: places,
+            about: about,
+            password: password
+        )
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Global/Errors/RequestError.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Global/Errors/RequestError.swift
@@ -1,0 +1,35 @@
+//
+//  RequestError.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 4/28/25.
+//
+
+enum RequestError: Error {
+    case decode
+    case invalidURL
+    case noResponse
+    case unauthorized
+    case unexpectedStatusCode
+    case errorWithLog(String)
+    case unknown
+
+    var message: String {
+        switch self {
+        case .decode:
+            return "Decode"
+        case .invalidURL:
+            return "Session expired"
+        case .noResponse:
+            return "noResponse"
+        case .unauthorized:
+            return "unauthorized"
+        case .unexpectedStatusCode:
+            return "unexpected"
+        case .errorWithLog(let errorLog):
+            return errorLog
+        case .unknown:
+            return "unknown"
+        }
+    }
+}


### PR DESCRIPTION
## 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 

Clean Architecture 를 적용하여 Network 관련 부분 작업 완료하였습니다. Auth 관련 회원가입 API 구현 및 호출을 예시로 봐주시면 좋을 것 같습니다. 

### HTTPClient 프로토콜 및 기본 request 구현 추가
- 공통 네트워크 요청을 담당할 HTTPClient 프로토콜 정의
- URLComponents를 사용하여 URL 구성
- URLSession을 이용해 비동기 데이터 요청 처리
- 응답 상태코드에 따른 오류 처리 및 JSON 디코딩 지원

### 네트워크 응답 에러 타입 enum 추가
- 네트워크 응답 에러 타입 Enum 을 추가하였습니다.

### 통신 Endpoint 프로토콜 및 Auth 관련 Endpoint 구현

- 통신 Endpoint 프로토콜 및 Auth 관련 Endpoint를 구현하였습니다.
  - 회원가입, 로그인, 로그아웃, 회원탈퇴 등에 대한 API Endpoint를 정의합니다.

추후 각 도메인(회원정보 관련, 다이버정보 관련)에 따라 Endpoint 를 나누어 추가하면 좋을 것 같습니다.
ex) 다이버 정보 관련 API : DiverBookDiverInfoEndpoint.swift

### 회원가입 DTO 및 도메인 변환을 위한 Extension 구현 (Data Layer)
- 회원가입 DTO 및 도메인 변환을 위한 Extension을 구현하였습니다.

### DefaultAuthRepository, DiverBookAuthServicable, DiverBookTokenServicable 구현 (Repository Layer)

- DefaultAuthRepository (UseCase 레이어의 AuthRepository 프로토콜 구현체)
- DiverBookAuthServicable(프로토콜)
- DiverBookTokenServicable(프로토콜)
을 구현하였습니다.

DefaultAuthRepository는 UseCase 레이어의 AuthRepository 프로토콜을 구현하여 UseCase <- Repository 의 의존성 방향을 만족합니다.

또한 Repository 레이어에 DiverBookAuthServicable, DiverBookTokenServicable 프로토콜을 구현하여 Data 레이어(해당 Servicable 들의 구현체가 있는 레이어) 와는 Repository <- Data 의 의존성 방향을 만족합니다.

### Auth관련 UseCase 레이어 구현
Auth관련 UseCase 레이어를 구현하였습니다.

UseCase 레이어에는
1. UseCase protocol
2. UseCase 구현체
3. Repository 레이어에서 구현할 Repository 프로토콜

세 가지가 위치합니다.

### DiverBookAuthService(API), DiverBookTokenService(Local DB)의 기능을 수행하는 Services 구현 (Data Layer)

DiverBookAuthService(API), DiverBookTokenService(Local DB)의 기능을 수행하는 Services를 구현하였습니다.

- UserDefaultWrapper: UserDefaults를 ProperyWrapper 로 감싸 사용하기 편하도록 해주는 역할
```Swift
@userdefault(key: "ex", defaultValue: "")
static var ex: String
```
처럼 사용 가능합니다.

- UserToken: 서버로부터 SignUp API를 호출하였을 때 받아오는 토큰, id 값을 관리하는 역할
- DiverBookAuthService: Repository 레이어의 DiverBookAuthServicable 을 구현
- DiverBookTokenService: Repository 레이어의 DiverBookTokenServicable 을 구현

### 회원가입 시 DTO 를 적절한 형태로 가공할 수 있도록 AuthInfo 구조체 구현 (Entity Layer)

회원가입 시 DTO 를 적절한 형태로 가공할 수 있도록 AuthInfo 구조체를 구현하였습니다.

- 해당 구조체는 Entity 레이어의 외부 레이어에서 사용될 수 있습니다.