### PR TITLE
[feat] 설정 UI 구현

### DIFF
--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/Coordinator.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/Coordinator.swift
@@ -34,5 +34,4 @@ enum Path: Hashable {
     case finishConversation
     case myProfile
     case privacyPolicy
-    case settingTab
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/Coordinator.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/Coordinator.swift
@@ -32,4 +32,7 @@ enum Path: Hashable {
     case searchResult(nickname: String)
     case startConversation
     case finishConversation
+    case myProfile
+    case privacyPolicy
+    case settingTab
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -45,8 +45,10 @@ struct DiverBookIOSApp: App {
                                 DiverProfileView(viewModel: DiverProfileViewModel())
                             case .myProfile:
                                 MyProfileView(viewModel: MyProfileViewModel())
+                                    .toolbar(.hidden, for: .navigationBar)
                             case .privacyPolicy:
                                 PrivacyPolicyView()
+                                    .toolbar(.hidden, for: .navigationBar)
                             }
                         })
             }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -9,7 +9,8 @@ struct DiverBookIOSApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationStack(path: self.$coordinator.path) {
-                OnboardingView(coordinator: self.coordinator)
+                DiverBookTabView(coordinator: self.coordinator)
+                    .toolbar(.hidden, for: .navigationBar)
                     .navigationDestination(
                         for: Path.self,
                         destination: { path in
@@ -46,8 +47,6 @@ struct DiverBookIOSApp: App {
                                 MyProfileView(viewModel: MyProfileViewModel())
                             case .privacyPolicy:
                                 PrivacyPolicyView()
-                            case .settingTab:
-                                SystemSettingView(coordinator: self.coordinator)
                             }
                         })
             }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -42,6 +42,12 @@ struct DiverBookIOSApp: App {
                                     .toolbar(.hidden, for: .navigationBar)
                             case .finishConversation:
                                 DiverProfileView(viewModel: DiverProfileViewModel())
+                            case .myProfile:
+                                MyProfileView(viewModel: MyProfileViewModel())
+                            case .privacyPolicy:
+                                PrivacyPolicyView()
+                            case .settingTab:
+                                SystemSettingView(coordinator: self.coordinator)
                             }
                         })
             }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -9,7 +9,7 @@ struct DiverBookIOSApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationStack(path: self.$coordinator.path) {
-                DiverBookTabView(coordinator: self.coordinator)
+                OnboardingView(coordinator: self.coordinator)
                     .toolbar(.hidden, for: .navigationBar)
                     .navigationDestination(
                         for: Path.self,

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -41,7 +41,7 @@ struct DiverBookIOSApp: App {
                                 ConversationView(coordinator: self.coordinator)
                                     .toolbar(.hidden, for: .navigationBar)
                             case .finishConversation:
-                                ProfileView()
+                                DiverProfileView(viewModel: DiverProfileViewModel())
                             }
                         })
             }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverBookTabScene/View/DiverBookTabView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverBookTabScene/View/DiverBookTabView.swift
@@ -21,7 +21,7 @@ struct DiverBookTabView: View {
                 MainView(coordinator: self.viewModel.coordinator)
                     .tag(TabType.diverBook)
                 
-                Text("setting")
+                SystemSettingView(coordinator: self.viewModel.coordinator)
                     .tag(TabType.setting)
             }
             .tabViewStyle(.page)

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/View/MyProfileView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/View/MyProfileView.swift
@@ -15,29 +15,43 @@ struct MyProfileView: View {
     }
 
     var body: some View {
-        VStack(spacing: 34) {
-            VStack(spacing: 8) {
-                PrimaryProfile(image: Image("exMemoji"), style: .mypage)
+        VStack {
+            DiverProfileTopBarView()
+            
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 8) {
+                    PrimaryProfile(image: Image("exMemoji"), style: .mypage)
 
-                Text("Air")
-                    .font(DiveFont.headingH3)
+                    Text("Air")
+                        .font(DiveFont.headingH3)
+                }
+
+                TodayTalkSectionView(
+                    mode: .editable(binding: $viewModel.state.todayTalk)
+                )
+
+                Spacer().frame(height: 40)
+
+                ProfileDetailsInfoView(
+                    division: .editable(binding: $viewModel.state.division),
+                    phoneNumber: .editable(
+                        binding: $viewModel.state.phoneNumber
+                    ),
+                    interests: .editable(binding: $viewModel.state.interests),
+                    places: .editable(binding: $viewModel.state.places)
+                )
+
+                Spacer().frame(height: 32)
+
+                CollectedBadgeButtonView(badgeCount: viewModel.state.badgeCount)
+
+                Spacer()
+
             }
-
-            TodayTalkSectionView(mode: .editable(binding: $viewModel.state.todayTalk))
-
-            ProfileDetailsInfoView(
-                division: .editable(binding: $viewModel.state.division),
-                phoneNumber: .editable(binding: $viewModel.state.phoneNumber),
-                interests: .editable(binding: $viewModel.state.interests),
-                places: .editable(binding: $viewModel.state.places)
-            )
-            
-            CollectedBadgeButtonView(badgeCount: viewModel.state.badgeCount)
-            
-            Spacer()
         }
         .padding(.horizontal, 20)
     }
+
 }
 
 #Preview {

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/View/SubView/DiverProfileTopBarView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/View/SubView/DiverProfileTopBarView.swift
@@ -1,0 +1,20 @@
+//
+//  DiverProfileTopBarView.swift
+//  DiverBook_iOS
+//
+//  Created by jun on 5/2/25.
+//
+
+import Foundation
+import SwiftUI
+
+struct DiverProfileTopBarView: View {
+    var body: some View {
+        ZStack {
+            TopBar()
+            Text("내 프로필")
+                .font(DiveFont.bar)
+                .foregroundColor(DiveColor.gray4)
+        }
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SubView/PrivacyPolicyTopBarView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SubView/PrivacyPolicyTopBarView.swift
@@ -1,0 +1,23 @@
+//
+//  PrivacyPolicyTopBarView.swift
+//  DiverBook_iOS
+//
+//  Created by jun on 5/2/25.
+//
+
+import SwiftUI
+
+struct PrivacyPolicyTopBarView: View {
+    var body: some View {
+        ZStack {
+            TopBar()
+            Text("개인정보 이용 약관")
+                .font(DiveFont.bar)
+                .foregroundColor(DiveColor.gray4)
+        }
+    }
+}
+
+#Preview {
+    PrivacyPolicyTopBarView()
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SubView/PrivacyPolicyView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SubView/PrivacyPolicyView.swift
@@ -1,0 +1,45 @@
+
+import SwiftUI
+
+struct PrivacyPolicyView: View {
+    var body: some View {
+        ScrollView {
+            //TODO: 개인정보 이용 약관 수정 필요, 현재 임시로 작성
+            VStack(alignment: .leading, spacing: 16) {
+                Text("개인정보 이용 약관")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                    .padding(.top)
+
+                Text("""
+                이 앱은 사용자 개인정보 보호를 최우선으로 생각합니다.
+
+                수집하는 항목:
+                - 이름, 전화번호, 관심사 등 사용자 직접 입력 정보
+                - 앱 사용 중 생성되는 로그 데이터
+
+                수집 목적:
+                - 앱 기능 제공 및 개선
+                - 사용자 맞춤형 서비스 제공
+
+                보관 기간:
+                - 회원 탈퇴 시 즉시 파기되며, 법령에 따른 예외는 별도로 저장될 수 있습니다.
+
+                제3자 제공:
+                - 사용자 동의 없이 외부에 제공되지 않습니다.
+                """)
+
+                Spacer()
+            }
+            .padding(24)
+        }
+        .navigationTitle("개인정보 이용 약관")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        PrivacyPolicyView()
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SubView/PrivacyPolicyView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SubView/PrivacyPolicyView.swift
@@ -1,40 +1,36 @@
-
 import SwiftUI
 
 struct PrivacyPolicyView: View {
     var body: some View {
-        ScrollView {
+        VStack {
+            PrivacyPolicyTopBarView()
+            
             //TODO: 개인정보 이용 약관 수정 필요, 현재 임시로 작성
-            VStack(alignment: .leading, spacing: 16) {
-                Text("개인정보 이용 약관")
-                    .font(.title2)
-                    .fontWeight(.bold)
-                    .padding(.top)
+            ScrollView(showsIndicators: false) {
+                Text(
+                    """
+                    이 앱은 사용자 개인정보 보호를 최우선으로 생각합니다.
 
-                Text("""
-                이 앱은 사용자 개인정보 보호를 최우선으로 생각합니다.
+                    수집하는 항목:
+                    - 이름, 전화번호, 관심사 등 사용자 직접 입력 정보
+                    - 앱 사용 중 생성되는 로그 데이터
 
-                수집하는 항목:
-                - 이름, 전화번호, 관심사 등 사용자 직접 입력 정보
-                - 앱 사용 중 생성되는 로그 데이터
+                    수집 목적:
+                    - 앱 기능 제공 및 개선
+                    - 사용자 맞춤형 서비스 제공
 
-                수집 목적:
-                - 앱 기능 제공 및 개선
-                - 사용자 맞춤형 서비스 제공
+                    보관 기간:
+                    - 회원 탈퇴 시 즉시 파기되며, 법령에 따른 예외는 별도로 저장될 수 있습니다.
 
-                보관 기간:
-                - 회원 탈퇴 시 즉시 파기되며, 법령에 따른 예외는 별도로 저장될 수 있습니다.
-
-                제3자 제공:
-                - 사용자 동의 없이 외부에 제공되지 않습니다.
-                """)
+                    제3자 제공:
+                    - 사용자 동의 없이 외부에 제공되지 않습니다.
+                    """
+                )
 
                 Spacer()
             }
-            .padding(24)
         }
-        .navigationTitle("개인정보 이용 약관")
-        .navigationBarTitleDisplayMode(.inline)
+        .padding(.horizontal, 24)
     }
 }
 

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SubView/SettingRowView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SubView/SettingRowView.swift
@@ -1,0 +1,28 @@
+//
+//  SettingRowView.swift
+//  DiverBook_iOS
+//
+//  Created by jun on 5/2/25.
+//
+
+import SwiftUI
+
+struct SettingRowView: View {
+    let title: String
+    let action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            HStack {
+                Text(title)
+                    .foregroundStyle(DiveColor.black)
+                    .font(DiveFont.bodyMedium1)
+                Spacer()
+            }
+        }
+    }
+}
+
+#Preview {
+    SettingRowView(title: "내 프로필 관리", action: {})
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SubView/VersionInfoView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SubView/VersionInfoView.swift
@@ -1,0 +1,24 @@
+//
+//  VersionInfoView.swift
+//  DiverBook_iOS
+//
+//  Created by jun on 5/2/25.
+//
+
+import SwiftUI
+
+struct VersionInfoView: View {
+    var body: some View {
+        HStack {
+            Spacer()
+            
+            Text("버전 정보 \(Version.current)")
+                .foregroundStyle(DiveColor.gray2)
+                .font(DiveFont.bodyMedium1)
+        }
+    }
+}
+
+#Preview {
+    VersionInfoView()
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SystemSettingView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SystemSettingView.swift
@@ -1,0 +1,57 @@
+//
+//  SystemSettingView.swift
+//  DiverBook_iOS
+//
+//  Created by jun on 5/2/25.
+//
+
+import SwiftUI
+
+struct SystemSettingView: View {
+    @StateObject private var viewModel: SystemSettingViewModel
+
+    init(viewModel: SystemSettingViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            SettingRowView(title: "내 프로필 관리") {
+                viewModel.action(.tapProfile)
+            }
+
+            SettingRowView(title: "개인정보 이용 약관") {
+                viewModel.action(.tapPolicy)
+            }
+
+            SettingRowView(title: "회원탈퇴") {
+                viewModel.action(.tapWithdraw)
+            }
+
+            Spacer().frame(height: 10)
+
+            VersionInfoView()
+
+            Spacer()
+
+        }
+        .padding(24)
+        .navigationTitle("설정")
+        .navigationBarTitleDisplayMode(.inline)
+        .alert(
+            "정말 회원탈퇴 하시겠습니까?",
+            isPresented: $viewModel.state.showWithdrawAlert
+        ) {
+            Button("취소", role: .cancel) {
+                viewModel.action(.dismissAlert)
+            }
+            Button("탈퇴", role: .destructive) {
+                viewModel.action(.confirmWithdraw)
+            }
+        }
+    }
+}
+
+#Preview {
+    SystemSettingView(viewModel: SystemSettingViewModel())
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SystemSettingView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SystemSettingView.swift
@@ -15,7 +15,15 @@ struct SystemSettingView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 24) {
+        VStack(alignment: .leading, spacing: 32) {
+            HStack {
+                Spacer()
+                Text("설정")
+                    .font(DiveFont.bar)
+                    .foregroundColor(DiveColor.gray4)
+                Spacer()
+            }
+
             SettingRowView(title: "내 프로필 관리") {
                 viewModel.action(.tapProfile)
             }
@@ -36,8 +44,6 @@ struct SystemSettingView: View {
 
         }
         .padding(24)
-        .navigationTitle("설정")
-        .navigationBarTitleDisplayMode(.inline)
         .alert(
             "정말 회원탈퇴 하시겠습니까?",
             isPresented: $viewModel.state.showWithdrawAlert

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SystemSettingView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/SystemSettingView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 struct SystemSettingView: View {
     @StateObject private var viewModel: SystemSettingViewModel
 
-    init(viewModel: SystemSettingViewModel) {
-        _viewModel = StateObject(wrappedValue: viewModel)
+    init(coordinator: Coordinator) {
+        _viewModel = StateObject(wrappedValue: SystemSettingViewModel(coordinator: coordinator))
     }
 
     var body: some View {
@@ -50,8 +50,4 @@ struct SystemSettingView: View {
             }
         }
     }
-}
-
-#Preview {
-    SystemSettingView(viewModel: SystemSettingViewModel())
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/ViewModel/SystemSettingViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/ViewModel/SystemSettingViewModel.swift
@@ -5,35 +5,43 @@
 //  Created by jun on 5/2/25.
 //
 
+import Combine
 import Foundation
+import SwiftUICore
 
-final class SystemSettingViewModel: ViewModelable{
-    struct State{
+final class SystemSettingViewModel: ViewModelable {
+    struct State {
         var showWithdrawAlert: Bool = false
     }
-    
-    enum Action{
+
+    enum Action {
         case tapProfile
         case tapPolicy
         case tapWithdraw
         case dismissAlert
         case confirmWithdraw
     }
-    
+
     @Published var state = State()
-    
+    @ObservedObject var coordinator: Coordinator
+
+    init(coordinator: Coordinator) {
+        self.coordinator = coordinator
+    }
+
     func action(_ action: Action) {
         switch action {
         case .tapProfile:
-            print("Navigate to: 내 프로필 관리")
+            coordinator.push(.myProfile)
         case .tapPolicy:
-            print("Navigate to: 개인 정보 이용 약관")
+            coordinator.push(.privacyPolicy)
         case .tapWithdraw:
             state.showWithdrawAlert = true
         case .dismissAlert:
             state.showWithdrawAlert = false
         case .confirmWithdraw:
             print("탈퇴 처리")
+            //TODO: 탈퇴 로직 추가
             state.showWithdrawAlert = false
         }
     }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/ViewModel/SystemSettingViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/ViewModel/SystemSettingViewModel.swift
@@ -1,0 +1,40 @@
+//
+//  SystemSettingViewModel.swift
+//  DiverBook_iOS
+//
+//  Created by jun on 5/2/25.
+//
+
+import Foundation
+
+final class SystemSettingViewModel: ViewModelable{
+    struct State{
+        var showWithdrawAlert: Bool = false
+    }
+    
+    enum Action{
+        case tapProfile
+        case tapPolicy
+        case tapWithdraw
+        case dismissAlert
+        case confirmWithdraw
+    }
+    
+    @Published var state = State()
+    
+    func action(_ action: Action) {
+        switch action {
+        case .tapProfile:
+            print("Navigate to: 내 프로필 관리")
+        case .tapPolicy:
+            print("Navigate to: 개인 정보 이용 약관")
+        case .tapWithdraw:
+            state.showWithdrawAlert = true
+        case .dismissAlert:
+            state.showWithdrawAlert = false
+        case .confirmWithdraw:
+            print("탈퇴 처리")
+            state.showWithdrawAlert = false
+        }
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Version/Version.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Version/Version.swift
@@ -1,0 +1,14 @@
+//
+//  Version.swift
+//  DiverBook_iOS
+//
+//  Created by jun on 5/2/25.
+//
+
+import Foundation
+
+struct Version {
+    static var current: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+    }
+}


### PR DESCRIPTION
## 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
- [ ] 설정 UI 구현
- [ ] 하단 탭 "설정" 클릭 시 설정 뷰로 이동 
- [ ] "내 프로필 관리" 클릭 시 내 프로필 뷰로 이동
- [ ] "개인정보 이용 약관" 클릭 시 개인정보 이용약관 뷰로 이동 (현재 개인정보 이용약관 내용 임시 작성)
- [ ] "회원탈퇴" 클릭 시 회원탈퇴 alert 구현 (회원 탈퇴 로직 구현 필요)

## 📌 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
### 특이 사항 1
- 설명

https://github.com/user-attachments/assets/91545b0d-8add-4570-ae1a-78d81c584146


## ✅ 다음 해야 할 일
- [ ]  뱃지 획득 시 나오는 뷰 구현
- [ ]  "수집한 뱃지" 클릭 시 collectedBadge 뷰로 이동
- [ ]  애니메이션 / 쉐도우 디자인 적용
- [ ] 회원탈퇴 클릭 시 회원탈퇴 기능 필요
