### PR TITLE
[feat] 다이버 프로필 정보 네트워크 통신

### DIFF
--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/Coordinator.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/Coordinator.swift
@@ -29,7 +29,7 @@ enum Path: Hashable {
     case idCardScan
     case mainTab
     case searchingDiver
-    case searchResult(nickname: String)
+    case searchResult(diverID: String)
     case startConversation
     case finishConversation
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -34,8 +34,11 @@ struct DiverBookIOSApp: App {
                             case .searchingDiver:
                                 DiverSearchingView(coordinator: self.coordinator)
                                     .toolbar(.hidden, for: .navigationBar)
-                            case .searchResult(nickname: let nickname):
-                                DiverSearchResultView(nickname: nickname, coordinator: self.coordinator)
+                            case .searchResult(diverID: let diverID):
+                                DiverSearchResultView(
+                                    diverID: diverID,
+                                    coordinator: self.coordinator
+                                )
                                     .toolbar(.hidden, for: .navigationBar)
                             case .startConversation:
                                 ConversationView(coordinator: self.coordinator)

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/DiverBookTokenEndpoint.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/DiverBookTokenEndpoint.swift
@@ -1,0 +1,50 @@
+//
+//  DiverBookTokenEndpoint.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 5/3/25.
+//
+
+import Foundation
+
+enum DiverBookTokenEndpoint: Endpoint {
+    case refreshToken(refreshToken: String)
+    
+    var path: String {
+        switch self {
+        case .refreshToken:
+            return "/api/auth/refresh"
+        }
+    }
+    
+    var method: RequestMethod {
+        switch self {
+        case .refreshToken:
+            return .post
+        }
+    }
+    
+    var query: [String: String]? {
+        switch self {
+        default:
+            return nil
+        }
+    }
+    
+    var header: [String: String]? {
+        switch self {
+        case .refreshToken:
+            return [
+                "accept": "*/*",
+                "Content-Type": "application/json"
+            ]
+        }
+    }
+    
+    var body: [String: String]? {
+        switch self {
+        case .refreshToken(let refreshToken):
+            return ["refreshToken": refreshToken]
+        }
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/DiverProfileEndpoint.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/DiverProfileEndpoint.swift
@@ -1,0 +1,51 @@
+//
+//  DiverInfoEndpoint.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 4/30/25.
+//
+
+import Foundation
+
+enum DiverProfileEndpoint: Endpoint {
+    case diverProfile(id: String)
+    
+    var path: String {
+        switch self {
+        case .diverProfile(let id):
+            return "/api/users/\(id)"
+        }
+    }
+    
+    var method: RequestMethod {
+        switch self {
+        default:
+            return .get
+        }
+    }
+    
+    var query: [String: String]? {
+        switch self {
+        default:
+            return nil
+        }
+    }
+    
+    var header: [String: String]? {
+        switch self {
+        default:
+            return [
+                "accept": "*/*",
+                "Content-Type": "application/json",
+                "Authorization": "\(UserToken.tokenType) \(UserToken.accessToken)"
+            ]
+        }
+    }
+    
+    var body: [String: String]? {
+        switch self {
+        default:
+            return nil
+        }
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/ResponseModels/BaseResponse.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/ResponseModels/BaseResponse.swift
@@ -1,0 +1,12 @@
+//
+//  BaseResponse.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 5/3/25.
+//
+
+struct BaseResponse<T: Decodable>: Decodable {
+    let success: Bool
+    let data: T?
+    let errorMessage: String?
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/ResponseModels/DiverProfileResModel+Mapping.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/ResponseModels/DiverProfileResModel+Mapping.swift
@@ -1,0 +1,34 @@
+//
+//  DiverProfileModel+Mapping.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 4/30/25.
+//
+
+import Foundation
+
+struct DiverProfileResModel: Decodable {
+    var id: String
+    var userName: String
+    var divisions: String?
+    var phoneNumber: String?
+    var interests: String?
+    var places: String?
+    var about: String?
+    var profileImageUrl: String
+}
+
+extension DiverProfileResModel {
+    func toDomain() -> DiverProfile {
+        return .init(
+            id: id,
+            userName: userName,
+            divisions: divisions ?? "",
+            phoneNumber: phoneNumber ?? "",
+            interests: interests ?? "",
+            places: places ?? "",
+            about: about ?? "",
+            profileImageUrl: profileImageUrl
+        )
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/ResponseModels/RefreshTokenResModel+Mapping.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/ResponseModels/RefreshTokenResModel+Mapping.swift
@@ -1,0 +1,24 @@
+//
+//  RefreshTokenResModel+Mapping.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 5/2/25.
+//
+
+struct RefreshTokenResModel: Decodable {
+    var id: String
+    var accessToken: String
+    var refreshToken: String
+    var tokenType: String
+}
+
+// MARK: - Mappings to Domain
+extension RefreshTokenResModel {
+    func toDomain() -> AuthInfo {
+        return .init(
+            id: id,
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            tokenType: tokenType)
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/DiverBookAuthService.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/DiverBookAuthService.swift
@@ -28,4 +28,11 @@ final class DiverBookAuthService: DiverBookAuthServicable {
             responseModel: SignUpResModel.self)
     }
 
+    func refreshToken(
+        refreshToken: String
+    ) async -> Result<BaseResponse<RefreshTokenResModel>, RequestError> {
+        return await request(
+            endpoint: DiverBookTokenEndpoint.refreshToken(refreshToken: refreshToken),
+            responseModel: BaseResponse<RefreshTokenResModel>.self)
+    }
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/DiverProfileService.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/DiverProfileService.swift
@@ -1,0 +1,17 @@
+//
+//  DiverProfileService.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 5/1/25.
+//
+
+final class DiverProfileService: DiverProfileServicable {
+    func fetchDiverProfile(
+        id: String
+    ) async -> Result<BaseResponse<DiverProfileResModel>, RequestError> {
+        return await request(
+            endpoint: DiverProfileEndpoint.diverProfile(id: id),
+            responseModel: BaseResponse<DiverProfileResModel>.self
+        )
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/DefaultDiverRepository.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/DefaultDiverRepository.swift
@@ -1,0 +1,31 @@
+//
+//  DefaultDiverRepository.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 5/1/25.
+//
+
+final class DefaultDiverRepository: DiverRepository {
+    private let diverProfileService: DiverProfileServicable
+    
+    init(diverProfileService: DiverProfileServicable) {
+        self.diverProfileService = diverProfileService
+    }
+    
+    func fetchDiverProfile(id: String) async -> Result<DiverProfile, Error> {
+        let profileResult = await diverProfileService.fetchDiverProfile(id: id)
+        
+        switch profileResult {
+        case .success(let baseResponse):
+            if baseResponse.success, let data = baseResponse.data {
+                let diverProfile = data.toDomain()
+                return .success(diverProfile)
+            } else {
+                let errorMessage = baseResponse.errorMessage ?? "Error"
+                return .failure(RequestError.unknown)
+            }
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/DiverBookAuthServicable.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/DiverBookAuthServicable.swift
@@ -15,4 +15,8 @@ protocol DiverBookAuthServicable: HTTPClient {
         about: String,
         password: String
     ) async -> Result<SignUpResModel, RequestError>
+    
+    func refreshToken(
+        refreshToken: String
+    ) async -> Result<BaseResponse<RefreshTokenResModel>, RequestError>
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/DiverProfileServicable.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/DiverProfileServicable.swift
@@ -1,0 +1,12 @@
+//
+//  DiverProfileServicable.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 5/1/25.
+//
+
+protocol DiverProfileServicable: HTTPClient {
+    func fetchDiverProfile(
+        id: String
+    ) async -> Result<BaseResponse<DiverProfileResModel>, RequestError>
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/UserDefaults/UserToken.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/UserDefaults/UserToken.swift
@@ -18,3 +18,13 @@ struct UserToken {
     @UserDefault(key: "id", defaultValue: "")
     static var id: String
 }
+
+// MARK: RefreshToken을 위한 update 메서드
+extension UserToken {
+    static func updateTokens(authInfo: AuthInfo) {
+        self.accessToken = authInfo.accessToken
+        self.refreshToken = authInfo.refreshToken
+        self.tokenType = authInfo.tokenType
+        self.id = authInfo.id
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Common/TokenRefreshHandler.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Common/TokenRefreshHandler.swift
@@ -1,0 +1,33 @@
+//
+//  TokenRefreshHandler.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 5/3/25.
+//
+
+import Foundation
+
+struct TokenRefreshHandler {
+    static func withTokenRefresh<T>(
+        operation: @escaping () async -> Result<T, Error>,
+        refreshTokenUseCase: FetchRefreshTokenUseCase
+    ) async -> Result<T, Error> {
+        let result = await operation()
+
+        if case .failure(let error) = result,
+           let requestError = error as? RequestError,
+           requestError == .unauthorized {
+            let refreshToken = UserToken.refreshToken
+            let refreshResult = await refreshTokenUseCase.exeute(refreshToken: refreshToken)
+
+            switch refreshResult {
+            case .success(let newAuthInfo):
+                UserToken.updateTokens(authInfo: newAuthInfo)
+                return await operation()
+            case .failure(let refreshError):
+                return .failure(refreshError)
+            }
+        }
+        return result
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Entities/DiverProfile.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Entities/DiverProfile.swift
@@ -1,0 +1,17 @@
+//
+//  DiverInfo.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 4/30/25.
+//
+
+struct DiverProfile {
+    var id: String
+    var userName: String
+    var divisions: String
+    var phoneNumber: String
+    var interests: String
+    var places: String
+    var about: String
+    var profileImageUrl: String
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/AuthRepository.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/AuthRepository.swift
@@ -15,4 +15,8 @@ protocol AuthRepository {
         about: String,
         password: String
     ) async -> Result<Bool, Error>
+    
+    func refreshToken(
+        refreshToken: String
+    ) async -> Result<AuthInfo, Error>
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/DiverRepository.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/DiverRepository.swift
@@ -1,0 +1,10 @@
+//
+//  DiverRepository.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 5/1/25.
+//
+
+protocol DiverRepository {
+    func fetchDiverProfile(id: String) async -> Result<DiverProfile, Error>
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/FetchDiverProfileUseCase/DefaultFetchDiverProfileUseCase.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/FetchDiverProfileUseCase/DefaultFetchDiverProfileUseCase.swift
@@ -1,0 +1,18 @@
+//
+//  DefaultFetchDiverProfileUseCase.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 5/1/25.
+//
+
+final class DefaultFetchDiverProfileUseCase: FetchDiverProfileUseCase {
+    private let repository: DiverRepository
+    
+    init(repository: DiverRepository) {
+        self.repository = repository
+    }
+    
+    func executeFetchProfile(id: String) async -> Result<DiverProfile, Error> {
+        return await repository.fetchDiverProfile(id: id)
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/FetchDiverProfileUseCase/FetchDiverProfileUseCase.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/FetchDiverProfileUseCase/FetchDiverProfileUseCase.swift
@@ -1,0 +1,10 @@
+//
+//  FetchDiverProfileUseCase.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 5/1/25.
+//
+
+protocol FetchDiverProfileUseCase {
+    func executeFetchProfile(id: String) async -> Result<DiverProfile, Error>
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/RefreshTokenUseCase/DefaultFetchRefreshTokenUseCase.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/RefreshTokenUseCase/DefaultFetchRefreshTokenUseCase.swift
@@ -1,0 +1,18 @@
+//
+//  DefaultFetchRefreshTokenUseCase.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 5/3/25.
+//
+
+final class DefaultFetchRefreshTokenUseCase: FetchRefreshTokenUseCase {
+    private let repository: AuthRepository
+    
+    init(repository: AuthRepository) {
+        self.repository = repository
+    }
+    
+    func exeute(refreshToken: String) async -> Result<AuthInfo, Error> {
+        return await repository.refreshToken(refreshToken: refreshToken)
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/RefreshTokenUseCase/FetchRefreshTokenUseCase.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/RefreshTokenUseCase/FetchRefreshTokenUseCase.swift
@@ -1,0 +1,10 @@
+//
+//  FetchRefreshTokenUseCase.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 5/3/25.
+//
+
+protocol FetchRefreshTokenUseCase {
+    func exeute(refreshToken: String) async -> Result<AuthInfo, Error>
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Global/Errors/RequestError.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Global/Errors/RequestError.swift
@@ -5,7 +5,7 @@
 //  Created by 한건희 on 4/28/25.
 //
 
-enum RequestError: Error {
+enum RequestError: Error, Equatable {
     case decode
     case invalidURL
     case noResponse

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/View/DiverSearchResultView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/View/DiverSearchResultView.swift
@@ -10,10 +10,10 @@ import SwiftUI
 struct DiverSearchResultView: View {
     @StateObject var viewModel: DiverSearchResultViewModel
         
-    let nickname: String
+    let diverID: String
 
-    init(nickname: String, coordinator: Coordinator) {
-        self.nickname = nickname
+    init(diverID: String, coordinator: Coordinator) {
+        self.diverID = diverID
         _viewModel = StateObject(
             wrappedValue: DiverSearchResultViewModel(coordinator: coordinator))
     }
@@ -25,7 +25,8 @@ struct DiverSearchResultView: View {
             Group {
                 Text("심해를 탐험하는")
                     .foregroundColor(DiveColor.gray4)
-                Text("\(nickname) ")
+                // TODO: id 이용해 닉네임과 이미지 받아와 표시
+                Text("\(diverID) ")
                     .foregroundColor(DiveColor.color6)
                 + Text("발견!")
                     .foregroundColor(DiveColor.gray4)

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/ViewModel/DiverSearchResultViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/ViewModel/DiverSearchResultViewModel.swift
@@ -10,23 +10,54 @@ import SwiftUI
 
 final class DiverSearchResultViewModel: ViewModelable {
     struct State {
+        var diverInfo: DiverProfile?
+        var errorMessage: String?
     }
     
     enum Action {
         case startConversation
+        case loadDiverProfile(id: String)
     }
     
     @Published var state: State = State()
     @ObservedObject var coordinator: Coordinator
     
-    init(coordinator: Coordinator) {
+    private let fetchDiverProfileUseCase: FetchDiverProfileUseCase
+    private let fetchRefreshTokenUseCase: FetchRefreshTokenUseCase
+    
+    init(
+        coordinator: Coordinator,
+        fetchDiverProfileUseCase: FetchDiverProfileUseCase,
+        fetchRefreshTokenUseCase: FetchRefreshTokenUseCase
+    ) {
         self.coordinator = coordinator
+        self.fetchDiverProfileUseCase = fetchDiverProfileUseCase
+        self.fetchRefreshTokenUseCase = fetchRefreshTokenUseCase
     }
     
     func action(_ action: Action) {
         switch action {
         case .startConversation:
             coordinator.push(.startConversation)
+        case .loadDiverProfile(let id):
+            Task {
+                await loadDiverProfileData(id: id)
+            }
+        }
+    }
+    
+    private func loadDiverProfileData(id: String) async {
+        async let infoResult = TokenRefreshHandler.withTokenRefresh(
+            operation: { await self.fetchDiverProfileUseCase.executeFetchProfile(id: id) },
+            refreshTokenUseCase: fetchRefreshTokenUseCase)
+        
+        let diverInfoResult = await infoResult
+        
+        switch diverInfoResult {
+        case .success(let info):
+            state.diverInfo = info
+        case .failure(let error):
+            print("Failed to fetch diver info: \(error)")
         }
     }
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/ViewModel/DiverSearchingViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/ViewModel/DiverSearchingViewModel.swift
@@ -13,27 +13,26 @@ final class DiverSearchingViewModel: ViewModelable {
     }
     
     enum Action {
-        case successSearchingDiver(nickname: String)
+        case successSearchingDiver(diverID: String)
     }
     
     @Published var state: State = State()
     @ObservedObject var coordinator: Coordinator
     
-    private let nickname: String
+    private let userID: String
     private lazy var dataTransferManager: DataTransferManager = {
-        return DataTransferManager(nickname: nickname, viewModel: self)
+        return DataTransferManager(userID: userID, viewModel: self)
     }()
     
     init(coordinator: Coordinator) {
         self.coordinator = coordinator
-        // TODO: - 사용자 데이터에서 가져오기
-        self.nickname = "Berry"
+        self.userID = UserToken.id
     }
     
     func action(_ action: Action) {
         switch action {
-        case .successSearchingDiver(let nickname):
-            self.coordinator.push(.searchResult(nickname: nickname))
+        case .successSearchingDiver(let diverID):
+            self.coordinator.push(.searchResult(diverID: diverID))
         }
     }
     

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Service/Connectivity/DataTransferManager.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Service/Connectivity/DataTransferManager.swift
@@ -12,7 +12,7 @@ import NearbyInteraction
 final class DataTransferManager: NSObject, ObservableObject {
     var peerID: MCPeerID
     var session: MCSession
-    private let nickname: String
+    private let userID: String
     private var niSession: NISession?
     private var nearbyToken: NIDiscoveryToken?
     private var advertiserManager: AdvertiserManager?
@@ -24,12 +24,10 @@ final class DataTransferManager: NSObject, ObservableObject {
     private let minDistance: Float = 0.2
     private let maxDistance: Float = 0.3
 
-    // TODO: - 내 실제 닉네임 전달해주도록 변경
     @Published var isBrowser: Bool = false
-    @Published var receivedNickname: String = ""
 
-    init(nickname: String, viewModel: DiverSearchingViewModel) {
-        self.nickname = nickname
+    init(userID: String, viewModel: DiverSearchingViewModel) {
+        self.userID = userID
         self.viewModel = viewModel
         self.peerID = MCPeerID(displayName: UIDevice.current.name)
         self.session = MCSession(
@@ -80,7 +78,7 @@ final class DataTransferManager: NSObject, ObservableObject {
     
     private func sendNickname() {
         guard !session.connectedPeers.isEmpty,
-              let data = nickname.data(using: .utf8) else { return }
+              let data = userID.data(using: .utf8) else { return }
         try? session.send(data, toPeers: session.connectedPeers, with: .reliable)
         print("✅ sendNickname")
     }
@@ -111,13 +109,12 @@ extension DataTransferManager: MCSessionDelegate {
             return
         }
 
-        if let nickname = String(data: data, encoding: .utf8) {
+        if let diverID = String(data: data, encoding: .utf8) {
             DispatchQueue.main.async {
                 self.hapticManager.cutstomStrongHaptic()
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    self.receivedNickname = nickname
-                    self.viewModel?.action(.successSearchingDiver(nickname: nickname))
-                    print("✅ 받은 닉네임: \(nickname)")
+                    self.viewModel?.action(.successSearchingDiver(diverID: diverID))
+                    print("✅ 받은 닉네임: \(diverID)")
                 }
             }
         }


### PR DESCRIPTION
## 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] 다이버 프로필 가져오기
- [x] 토큰 만료의 경우 refresh 진행하기
- [x] 공통 응답 형태로 변경

## 📌 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
### 다이버 프로필 네트워크 통신
다이버 탐색 시점에 교환한 서로의 id를 통해 다이버 프로필 정보를 가져옵니다.
이때, 권한이 필요하기 때문에 AccessToken을 사용합니다.
현재 데이터 통신 잘 되고, 발견된 화면에 잘 뿌려집니다.
Image가 기존 String 형태에서 Url 형태로 변경되어 그 부분만 표시되지 않는 상태입니다.
이 부분은 다음 PR에서 전체적으로 ImageUrl 사용으로 변경하고 올리겠습니다.

### Token Refresh
AccessToken의 만료 시간은 30분 이기 때문에, 권한 관련 error가 발생한다면 재발급 받는 로직을 추가했습니다.
아래와 같이 사용 가능합니다.
동작은 operation에 실행할 내역을 넣고, 반환된 error가 .unAuthorized인 경우 재발급 실행 형태입니다.
```swift
TokenRefreshHandler.withTokenRefresh(
            operation: { await self.fetchDiverProfileUseCase.executeFetchProfile(id: id) },
            refreshTokenUseCase: fetchRefreshTokenUseCase)
```

### 공통 응답 형태
BaseResponse를 구현해두었습니다.
BaseResponse<ResModel> 형태로 사용 가능합니다.
Signup의 경우에는 따로 변경해두지 않아서 이후 수정해주시면 좋을 것 같습니다.

### 논의
현재 Endpoint의 body 부분은 [String: String]? 타입입니다.
추후에 body의 내용이 늘어날 경우를 대비해 Data? 형태로 변경하고 RequestModel 만들어 사용하면 어떨까 싶은데
다른 분들의 의견이 궁금합니다.
