### PR TITLE
[feat] 이미지 URL 사용으로 변경 및 mock 데이터 추가

### DIFF
--- a/DiverBook_iOS/DiverBook_iOS/Sources/Common/DesignSystem/PrimaryProfile.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Common/DesignSystem/PrimaryProfile.swift
@@ -8,16 +8,16 @@
 import SwiftUI
 
 struct PrimaryProfile: View {
-    let image: Image
+    let imageURL: URL?
     let nickname: String?
     let hasShadow: Bool
     let style: ProfileStyle
 
-    init(image: Image,
+    init(imageURL: URL?,
          nickname: String? = nil,
          hasShadow: Bool = true,
          style: ProfileStyle) {
-        self.image = image
+        self.imageURL = imageURL
         self.nickname = nickname
         self.hasShadow = hasShadow
         self.style = style
@@ -30,11 +30,11 @@ struct PrimaryProfile: View {
                     .fill((DiveColor.white))
                     .frame(width: style.imageSize, height: style.imageSize)
                     .applyShadow(hasShadow ? style.shadow : DiveShadow.noneShadow)
-                image
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: style.imageSize, height: style.imageSize)
-                    .clipShape(Circle())
+                ProfileImageView(
+                    imageURL: imageURL,
+                    style: style,
+                    placeholderImageName: "unfoundProfile"
+                )
             }
             
             if let nickname = nickname {
@@ -104,13 +104,19 @@ enum ProfileStyle {
 
 #Preview {
     // 러너 발견 시점 - found
-    PrimaryProfile(image: Image("exMemoji"), style: .found)
+    PrimaryProfile(imageURL: DiverProfile.mockData.profileImageUrl, style: .found)
     // 내 프로필 - mypage
-    PrimaryProfile(image: Image("exMemoji"), nickname: "Berry", style: .mypage)
+    PrimaryProfile(
+        imageURL: DiverProfile.mockData.profileImageUrl,
+        nickname: DiverProfile.mockData.userName,
+        style: .mypage)
     // 도감 목록 - diver
-    PrimaryProfile(image: Image("exMemoji"), nickname: "Berry", style: .diver)
+    PrimaryProfile(
+        imageURL: DiverProfile.mockData.profileImageUrl,
+        nickname: DiverProfile.mockData.userName,
+        style: .diver)
     // 기본 프로필(메인 화면과 다이버 카드) - basic
-    PrimaryProfile(image: Image("exMemoji"), style: .basic)
-    // shadow 필요없는 경우
-    PrimaryProfile(image: Image("exMemoji"), hasShadow: false, style: .basic)
+    PrimaryProfile(imageURL: DiverProfile.mockData.profileImageUrl, style: .basic)
+    // 미발견 프로필 - unfound
+    PrimaryProfile(imageURL: DiverProfile.unfoundMockData.profileImageUrl, style: .unfound)
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Common/DesignSystem/ProfileAsyncImage.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Common/DesignSystem/ProfileAsyncImage.swift
@@ -1,0 +1,47 @@
+//
+//  ProfileAsyncImage.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 5/4/25.
+//
+
+import Foundation
+import SwiftUI
+
+struct ProfileImageView: View {
+    let imageURL: URL?
+    let style: ProfileStyle
+    let placeholderImageName: String
+    
+    var body: some View {
+        if let imageURL = imageURL {
+            AsyncImage(url: imageURL) { phase in
+                switch phase {
+                case .empty:
+                    ProgressView()
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: style.imageSize, height: style.imageSize)
+                        .clipShape(Circle())
+                case .failure:
+                    Image(systemName: placeholderImageName)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: style.imageSize, height: style.imageSize)
+                        .clipShape(Circle())
+                        .foregroundColor(.gray)
+                @unknown default:
+                    EmptyView()
+                }
+            }
+        } else {
+            Image(placeholderImageName)
+                .resizable()
+                .scaledToFit()
+                .frame(width: style.imageSize, height: style.imageSize)
+                .clipShape(Circle())
+        }
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/ResponseModels/DiverProfileResModel+Mapping.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/ResponseModels/DiverProfileResModel+Mapping.swift
@@ -28,7 +28,7 @@ extension DiverProfileResModel {
             interests: interests ?? "",
             places: places ?? "",
             about: about ?? "",
-            profileImageUrl: profileImageUrl
+            profileImageUrlString: profileImageUrl
         )
     }
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Entities/DiverProfile.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Entities/DiverProfile.swift
@@ -5,6 +5,8 @@
 //  Created by 배현진 on 4/30/25.
 //
 
+import Foundation
+
 struct DiverProfile {
     var id: String
     var userName: String
@@ -13,5 +15,33 @@ struct DiverProfile {
     var interests: String
     var places: String
     var about: String
-    var profileImageUrl: String
+    var profileImageUrlString: String
+    
+    var profileImageUrl: URL? {
+        return URL(string: profileImageUrlString)
+    }
+}
+
+extension DiverProfile {
+    static let mockData = DiverProfile(
+        id: "",
+        userName: "Air",
+        divisions: "테크",
+        phoneNumber: "010-1234-1234",
+        interests: "사진, 공기",
+        places: "C5",
+        about: "공기는 눈에 보이지 않지만 어디에나 있습니다.",
+        profileImageUrlString: "https://diverbook.sijun.dev/api/images/view/Air.png"
+    )
+    
+    static let unfoundMockData = DiverProfile(
+        id: "",
+        userName: "Air",
+        divisions: "",
+        phoneNumber: "",
+        interests: "",
+        places: "",
+        about: "",
+        profileImageUrlString: ""
+    )
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/View/DiverProfileView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/View/DiverProfileView.swift
@@ -18,7 +18,7 @@ struct DiverProfileView: View {
         ScrollView {
             VStack(spacing: 26) {
                 DiverProfileHeaderSectionView(
-                    profileImageName: viewModel.state.profileImageName,
+                    profileImageURL: viewModel.state.profileImageURL,
                     name: viewModel.state.name,
                     foundDate: viewModel.state.foundDate
                 )

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/View/SubView/DiverProfileHeaderSectionView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/View/SubView/DiverProfileHeaderSectionView.swift
@@ -9,13 +9,13 @@ import Foundation
 import SwiftUI
 
 struct DiverProfileHeaderSectionView: View {
-    let profileImageName: String
+    let profileImageURL: URL?
     let name: String
     let foundDate: String
 
     var body: some View {
         HStack(spacing: 11) {
-            PrimaryProfile(image: Image(profileImageName), style: .basic)
+            PrimaryProfile(imageURL: profileImageURL, style: .basic)
 
             VStack(alignment: .leading, spacing: 6) {
                 Text(name)
@@ -32,8 +32,8 @@ struct DiverProfileHeaderSectionView: View {
 
 #Preview {
     DiverProfileHeaderSectionView(
-        profileImageName: "exMemoji",
-        name: "Chloe",
+        profileImageURL: DiverProfile.mockData.profileImageUrl,
+        name: DiverProfile.mockData.userName,
         foundDate: "25.03.24"
     )
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/ViewModel/DiverProfileViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/ViewModel/DiverProfileViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 
 final class DiverProfileViewModel: ViewModelable {
     struct State {
-        var profileImageName = ""
+        var profileImageURL: URL?
         var name: String = ""
         var foundDate: String = ""
         var todayTalk: String = ""
@@ -51,14 +51,14 @@ final class DiverProfileViewModel: ViewModelable {
 
     private func fetchDiverProfile() {
         self.state = State(
-            profileImageName: "exMemoji",
-            name: "Chloe",
+            profileImageURL: DiverProfile.mockData.profileImageUrl,
+            name: DiverProfile.mockData.userName,
             foundDate: "25.03.24",
-            todayTalk: "함께라서 즐거운 다이빙",
-            division: "iOS 개발",
-            phoneNumber: "010-1234-5678",
-            interests: "수영, 여행",
-            places: "C5"
+            todayTalk: DiverProfile.mockData.about,
+            division: DiverProfile.mockData.divisions,
+            phoneNumber: DiverProfile.mockData.phoneNumber,
+            interests: DiverProfile.mockData.interests,
+            places: DiverProfile.mockData.places
         )
         self.history = "처음 만난 날 기억나니?"
         self.originalHistory = history

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/View/DiverSearchResultView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/View/DiverSearchResultView.swift
@@ -48,7 +48,7 @@ struct DiverSearchResultView: View {
             .font(DiveFont.headingH1)
             
             if let diverImage = viewModel.state.diverInfo?.profileImageUrl {
-                PrimaryProfile(image: Image("\(diverImage)"), style: .found)
+                PrimaryProfile(imageURL: diverImage, style: .found)
                     .padding(.top, 20)
             }
             Spacer()

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MainScene/View/SubView/DiverCollectionListView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MainScene/View/SubView/DiverCollectionListView.swift
@@ -25,7 +25,7 @@ struct DiverCollectionListView: View {
             GridItem(.flexible(minimum: 80, maximum: 200))
         ]) {
             ForEach(0..<100) { index in
-                PrimaryProfile(image: Image("diver-air"), nickname: "Air", style: .diver)
+                PrimaryProfile(imageURL: DiverProfile.mockData.profileImageUrl, nickname: DiverProfile.mockData.userName, style: .diver)
             }
         }
     }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MainScene/View/SubView/MainDiverInfoView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MainScene/View/SubView/MainDiverInfoView.swift
@@ -12,7 +12,7 @@ struct MainDiverInfoView: View {
     @ObservedObject var viewModel: MainViewModel
     var body: some View {
         HStack(spacing: 0) {
-            PrimaryProfile(image: Image("diver-air"), style: .basic)
+            PrimaryProfile(imageURL: DiverProfile.mockData.profileImageUrl, style: .basic)
                 .padding(.trailing, 10)
             LearnerNicknameView(nickname: self.$viewModel.state.userNickname)
             Spacer()

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MainScene/ViewModel/MainViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MainScene/ViewModel/MainViewModel.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 class MainViewModel: ViewModelable {
     struct State {
-        var userNickname: String = "Ted"
+        var userNickname: String = DiverProfile.mockData.userName
         var bookAttainmentRate: Double = 50
     }
     

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/View/MyProfileView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/View/MyProfileView.swift
@@ -20,9 +20,9 @@ struct MyProfileView: View {
             
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 8) {
-                    PrimaryProfile(image: Image("exMemoji"), style: .mypage)
+                    PrimaryProfile(imageURL: DiverProfile.mockData.profileImageUrl, style: .mypage)
 
-                    Text("Air")
+                    Text(DiverProfile.mockData.userName)
                         .font(DiveFont.headingH3)
                 }
 

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/ViewModel/MyProfileViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/ViewModel/MyProfileViewModel.swift
@@ -61,11 +61,11 @@ final class MyProfileViewModel: ViewModelable {
     private func fetchProfileData() {
         // TODO: Mock 데이터 -> 서버 데이터 불러오기로 변경해야함
         self.state = State(
-            todayTalk: "공기는 눈에 보이지 않지만 어디에나 있습니다.",
-            division: "디자인",
-            phoneNumber: "010-1234-1234",
-            interests: "사진, 아마스빈",
-            places: "C5",
+            todayTalk: DiverProfile.mockData.about,
+            division: DiverProfile.mockData.divisions,
+            phoneNumber: DiverProfile.mockData.phoneNumber,
+            interests: DiverProfile.mockData.interests,
+            places: DiverProfile.mockData.places,
             badgeCount: 5
         )
     }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/UnfoundDiverScene/View/UnfoundDiverView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/UnfoundDiverScene/View/UnfoundDiverView.swift
@@ -18,7 +18,11 @@ struct UnfoundDiverView: View {
         VStack {
             UnfoundDiverTopBarView()
             Spacer()
-            PrimaryProfile(image: Image("unfoundProfile"), nickname: "Air", style: .unfound)
+            PrimaryProfile(
+                imageURL: DiverProfile.unfoundMockData.profileImageUrl,
+                nickname: DiverProfile.unfoundMockData.userName,
+                style: .unfound
+            )
             Text("아직 발견되지 않은 다이버입니다.")
                 .font(DiveFont.bodyMedium1)
                 .foregroundColor(DiveColor.gray3)


### PR DESCRIPTION
## 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] Image Url 이용으로 변경
- [x] 데이터 더미 관리용 mock 데이터 추가
- [x] 데이터 더미 사용 부분 mock 데이터 이용으로 변경

## 📌 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
### Image String -> URL
서버 단에서 Image를 URL 형태로 저장하고 이용하는 것으로 변경되었기 때문에 이에 맞춰 수정했습니다.
UrlString 형태로 서버에서 받아오면 Url 형태로 변경해 이용합니다.
PrimaryProfile에서 Url 이용해 이미지 표시하기 위해 AsyncImage 사용했습니다.
이미지 로딩 시점까지는 ProgressView로 표시되고, 이미지가 없는 경우 unfoundProfile(다이빙 고글 이미지) 사용됩니다.

### 데이터 더미
여기저기서 직접 하드 코딩 되어있던 데이터 더미 내역들 관리할 수 있도록
DiverProfile 타입 mockData 변수 추가했습니다.
데이터 더비 부분들 찾아 수정해두었습니다.
이제 데이터 더미 필요하면 아래 형태로 사용해주세요

```swift
DiverProfile.mockData.userName
DiverProfile.mockData.divisions
DiverProfile.mockData.phoneNumber
DiverProfile.mockData.interests
DiverProfile.mockData.places
DiverProfile.mockData.about
DiverProfile.mockData.profileImageUrlString
DiverProfile.mockData.profileImageUrl
```

