### PR TITLE
[feat] 아카데미 출입증 인식 UI ServiceErrorAlert 추가 및 메인 화면 컬렉션 조회 ResModel 변경

### DIFF
--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/Coordinator.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/Coordinator.swift
@@ -34,6 +34,5 @@ enum Path: Hashable {
     case startConversation
     case finishConversation
     case myProfile
-    case privacyPolicy
     case collectedBadge
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -9,7 +9,8 @@ struct DiverBookIOSApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationStack(path: self.$coordinator.path) {
-                OnboardingView(coordinator: self.coordinator)
+//                OnboardingView(coordinator: self.coordinator)
+                LoginView(nickname: "Jun", coordinator: coordinator)
                     .toolbar(.hidden, for: .navigationBar)
                     .navigationDestination(
                         for: Path.self,
@@ -57,8 +58,10 @@ struct DiverBookIOSApp: App {
                                 MyProfileView(coordinator: self.coordinator)
                                     .toolbar(.hidden, for: .navigationBar)
                             case .collectedBadge:
-                                CollectedBadgeView(viewModel: CollectedBadgeViewModel(registeredDiverCount: 5))
+                                CollectedBadgeView()
                                     .toolbar(.hidden, for: .navigationBar)
+                            case .privacyPolicy:
+                                Text("Privacy policy")
                             }
                         })
             }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -9,8 +9,7 @@ struct DiverBookIOSApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationStack(path: self.$coordinator.path) {
-//                OnboardingView(coordinator: self.coordinator)
-                LoginView(nickname: "Jun", coordinator: coordinator)
+                OnboardingView(coordinator: self.coordinator)
                     .toolbar(.hidden, for: .navigationBar)
                     .navigationDestination(
                         for: Path.self,
@@ -60,8 +59,6 @@ struct DiverBookIOSApp: App {
                             case .collectedBadge:
                                 CollectedBadgeView()
                                     .toolbar(.hidden, for: .navigationBar)
-                            case .privacyPolicy:
-                                Text("Privacy policy")
                             }
                         })
             }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/ResponseModels/CollectedDiverResModel+Mapping.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/ResponseModels/CollectedDiverResModel+Mapping.swift
@@ -1,0 +1,26 @@
+//
+//  CollectedDiverResModel.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 5/9/25.
+//
+
+struct CollectedDiverResModel: Decodable {
+    var id: Int
+    var ownerId: String
+    var foundUserId: String
+    var foundDate: String
+    var memo: String?
+}
+
+extension CollectedDiverResModel {
+    func toDomain() -> CollectedDiverInfo {
+        return CollectedDiverInfo(
+            id: id,
+            ownerId: ownerId,
+            foundUserId: foundUserId,
+            foundDate: foundDate,
+            memo: memo ?? ""
+        )
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/DiverCollectionService.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/DiverCollectionService.swift
@@ -13,10 +13,10 @@ final class DiverCollectionService: DiverCollectionServicable {
         )
     }
     
-    func fetchDiverCollection() async -> Result<BaseResponse<[DiverProfileResModel]>, RequestError> {
+    func fetchDiverCollection() async -> Result<BaseResponse<[CollectedDiverResModel]>, RequestError> {
         return await request(
             endpoint: DiverCollectionEndpoint.diverCollection,
-            responseModel: BaseResponse<[DiverProfileResModel]>.self
+            responseModel: BaseResponse<[CollectedDiverResModel]>.self
         )
     }
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/DefaultDiverCollectionRepository.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/DefaultDiverCollectionRepository.swift
@@ -28,7 +28,7 @@ final class DefaultDiverCollectionRepository: DiverCollectionRepository {
         }
     }
     
-    func fetchDiverCollection() async -> Result<[DiverProfile], Error> {
+    func fetchDiverCollection() async -> Result<[CollectedDiverInfo], Error> {
         let fetchDiverCollectionResult = await diverCollectionService.fetchDiverCollection()
         switch fetchDiverCollectionResult {
         case .success(let baseResponse):

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/DiverCollectionServicable.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/DiverCollectionServicable.swift
@@ -7,5 +7,5 @@
 
 protocol DiverCollectionServicable: HTTPClient {
     func fetchAllDiverList() async -> Result<BaseResponse<[DiverProfileResModel]>, RequestError>
-    func fetchDiverCollection() async -> Result<BaseResponse<[DiverProfileResModel]>, RequestError>
+    func fetchDiverCollection() async -> Result<BaseResponse<[CollectedDiverResModel]>, RequestError>
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/UserDefaults/LocalUserData.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/UserDefaults/LocalUserData.swift
@@ -1,0 +1,11 @@
+//
+//  LocalUserData.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 5/10/25.
+//
+
+struct LocalUserData {
+    @UserDefault(key: "collectedUserCount", defaultValue: 0)
+    static var collectedUserCount: Int
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Entities/CollectedDiverInfo.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Entities/CollectedDiverInfo.swift
@@ -1,0 +1,14 @@
+//
+//  CollectedDiverInfo.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 5/9/25.
+//
+
+struct CollectedDiverInfo {
+    var id: Int
+    var ownerId: String
+    var foundUserId: String
+    var foundDate: String
+    var memo: String
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/DiverCollectionRepository.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/DiverCollectionRepository.swift
@@ -7,5 +7,5 @@
 
 protocol DiverCollectionRepository {
     func fetchAllDiverList() async -> Result<[DiverProfile], Error>
-    func fetchDiverCollection() async -> Result<[DiverProfile], Error>
+    func fetchDiverCollection() async -> Result<[CollectedDiverInfo], Error>
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/DiverCollectionUseCase/DefaultDiverCollectionUseCase.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/DiverCollectionUseCase/DefaultDiverCollectionUseCase.swift
@@ -23,7 +23,7 @@ final class DefaultDiverCollectionUseCase: DiverCollectionUseCase {
         }
     }
     
-    func executeFetchDiverCollection() async -> Result<[DiverProfile], Error> {
+    func executeFetchDiverCollection() async -> Result<[CollectedDiverInfo], Error> {
         let diverCollectionResult = await diverCollectionRepository.fetchDiverCollection()
         switch diverCollectionResult {
         case .success(let diverProfiles):

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/DiverCollectionUseCase/DiverCollectionUseCase.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/DiverCollectionUseCase/DiverCollectionUseCase.swift
@@ -7,5 +7,5 @@
 
 protocol DiverCollectionUseCase {
     func executeFetchAllDiverList() async -> Result<[DiverProfile], Error>
-    func executeFetchDiverCollection() async -> Result<[DiverProfile], Error>
+    func executeFetchDiverCollection() async -> Result<[CollectedDiverInfo], Error>
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/IDCardScannerScene/View/IDCardScannerView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/IDCardScannerScene/View/IDCardScannerView.swift
@@ -25,68 +25,13 @@ struct IDCardScannerView: View {
 
     @Environment(\.dismiss) var dismiss
     var body: some View {
-        VStack(spacing: 0) {
-            TopBar()
-            Spacer()
-            Text("아카데미 출입증을 준비해주세요").font(DiveFont.headingH3)
-                .padding(.bottom, 5)
-            Text("조명이나 배경에 따라 출입증이 제대로\n촬영되지 않을 수 있어요.")
-                .font(DiveFont.bodyMedium2)
-                .lineSpacing(3)
-                .multilineTextAlignment(.center)
-                .padding(.bottom, 45)
-            Image("idcard-image").resizable().aspectRatio(contentMode: .fit).frame(width: 241)
-            Spacer()
-            
-            PrimaryButton(title: "촬영하기", coordinator: Coordinator()) {
-                viewModel.action(.scanningButtonTapped)
-            }
-            .padding(.bottom, 20)
-        }
-        .padding(.horizontal, 24)
-        .sheet(
-            isPresented: self.$viewModel.state.showCamera,
-            onDismiss: {
-                self.viewModel.action(.inspectImage)
-            }
-        ) {
-            ImagePicker(selectedImage: self.$viewModel.state.capturedImage)
-                .ignoresSafeArea()
-        }
-        .alert(isPresented: self.$viewModel.state.goSettingAlertState) {
-            Alert(
-                title: Text("현재 카메라 사용에 대한 접근 권한이 없습니다."),
-                message: Text("설정 > DiverBook 탭에서 접근을 활성화 할 수 있습니다."),
-                primaryButton: .default(
-                    Text("설정으로 이동하기"),
-                    action: {
-                        // MARK: 탭 시 설정 페이지로 이동
-                        guard
-                            let settingURL = URL(
-                                string: UIApplication.openSettingsURLString),
-                            UIApplication.shared.canOpenURL(settingURL)
-                        else {
-                            return
-                        }
-
-                        UIApplication.shared.open(settingURL, options: [:])
-                    }), secondaryButton: .cancel())
-        }
-        .overlay(
-            VStack {
-                Spacer()
-                    .frame(height: 100)
-                Text("촬영 정보를 불러오는 중입니다")
-                    .font(DiveFont.headingH3)
-                Spacer()
-            }
-            .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
-            .background(.white)
-            .overlay(
-                ProgressView()
+        ZStack(alignment: .top) {
+            IDCardScannerContentView(viewModel: viewModel)
+            ServiceErrorAlert(
+                message: viewModel.state.errorMessage,
+                showErrorAlert: $viewModel.state.isErrorShowing
             )
-            .opacity(viewModel.state.isScanning ? 1 : 0)
-        )
+        }
     }
 }
 

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/IDCardScannerScene/View/SubView/IDCardScannerContentView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/IDCardScannerScene/View/SubView/IDCardScannerContentView.swift
@@ -1,0 +1,77 @@
+//
+//  IDCardScannerContentView.swift
+//  DiverBook_iOS
+//
+//  Created by 한건희 on 5/7/25.
+//
+
+import SwiftUI
+
+struct IDCardScannerContentView: View {
+    @ObservedObject var viewModel: IDCardScannerViewModel
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            TopBar()
+            Spacer()
+            Text("아카데미 출입증을 준비해주세요").font(DiveFont.headingH3)
+                .padding(.bottom, 5)
+            Text("조명이나 배경에 따라 출입증이 제대로\n촬영되지 않을 수 있어요.")
+                .font(DiveFont.bodyMedium2)
+                .lineSpacing(3)
+                .multilineTextAlignment(.center)
+                .padding(.bottom, 45)
+            Image("idcard-image").resizable().aspectRatio(contentMode: .fit).frame(width: 241)
+            Spacer()
+            
+            PrimaryButton(title: "촬영하기", coordinator: Coordinator()) {
+                viewModel.action(.scanningButtonTapped)
+            }
+            .padding(.bottom, 20)
+        }
+        .padding(.horizontal, 24)
+        .sheet(
+            isPresented: self.$viewModel.state.showCamera,
+            onDismiss: {
+                self.viewModel.action(.inspectImage)
+            }
+        ) {
+            ImagePicker(selectedImage: self.$viewModel.state.capturedImage)
+                .ignoresSafeArea()
+        }
+        .alert(isPresented: self.$viewModel.state.goSettingAlertState) {
+            Alert(
+                title: Text("현재 카메라 사용에 대한 접근 권한이 없습니다."),
+                message: Text("설정 > DiverBook 탭에서 접근을 활성화 할 수 있습니다."),
+                primaryButton: .default(
+                    Text("설정으로 이동하기"),
+                    action: {
+                        // MARK: 탭 시 설정 페이지로 이동
+                        guard
+                            let settingURL = URL(
+                                string: UIApplication.openSettingsURLString),
+                            UIApplication.shared.canOpenURL(settingURL)
+                        else {
+                            return
+                        }
+
+                        UIApplication.shared.open(settingURL, options: [:])
+                    }), secondaryButton: .cancel())
+        }
+        .overlay(
+            VStack {
+                Spacer()
+                    .frame(height: 100)
+                Text("촬영 정보를 불러오는 중입니다")
+                    .font(DiveFont.headingH3)
+                Spacer()
+            }
+            .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
+            .background(.white)
+            .overlay(
+                ProgressView()
+            )
+            .opacity(viewModel.state.isScanning ? 1 : 0)
+        )
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/IDCardScannerScene/ViewModel/IDCardScannerViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/IDCardScannerScene/ViewModel/IDCardScannerViewModel.swift
@@ -16,6 +16,10 @@ final class IDCardScannerViewModel: ViewModelable {
         var capturedImage: UIImage?
         var inspectionResult: String?
         var goSettingAlertState: Bool = false
+        
+        // error alert
+        var isErrorShowing: Bool = false
+        var errorMessage: String = ""
     }
     
     enum Action {
@@ -60,6 +64,12 @@ final class IDCardScannerViewModel: ViewModelable {
                         }
                     case .failure(let error):
                         // TODO: 출입증 카드 검사 실패 실패 모달 띄우기
+                        switch error {
+                        case .isNotIdCard:
+                            activateErrorAlert(message: "아카데미 출입증 인식에 실패하였습니다. 아카데미 출입증을 쾌적한 환경에서 촬영해주세요.")
+                        case .readIdCardNicknameFailed:
+                            activateErrorAlert(message: "닉네임 인식에 실패하였습니다.")
+                        }
                         print(error)
                     }
                     state.isScanning = false
@@ -105,5 +115,10 @@ final class IDCardScannerViewModel: ViewModelable {
                     self.state.showCamera = true
                 }
             })
+    }
+    
+    private func activateErrorAlert(message: String) {
+        state.errorMessage = message
+        state.isErrorShowing = true
     }
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MainScene/ViewModel/MainViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MainScene/ViewModel/MainViewModel.swift
@@ -133,6 +133,7 @@ final class MainViewModel: ViewModelable {
         switch diverCollectionResult {
         case .success(let diverProfiles):
             // MARK: 현재 내가 수집한 다이버 리스트
+            LocalUserData.collectedUserCount = diverProfiles.count
             for diverProfile in diverProfiles {
                 state.isFoundedDiver[String(diverProfile.id)] = true
             }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MainScene/ViewModel/MainViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MainScene/ViewModel/MainViewModel.swift
@@ -134,9 +134,8 @@ final class MainViewModel: ViewModelable {
         case .success(let diverProfiles):
             // MARK: 현재 내가 수집한 다이버 리스트
             for diverProfile in diverProfiles {
-                state.isFoundedDiver[diverProfile.id] = true
+                state.isFoundedDiver[String(diverProfile.id)] = true
             }
-            print(diverProfiles)
         case .failure:
             activateErrorAlert(message: "도감 사용자 리스트 조회에 실패하였습니다.")
         }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/ViewModel/SystemSettingViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/ViewModel/SystemSettingViewModel.swift
@@ -33,7 +33,7 @@ final class SystemSettingViewModel: ViewModelable {
 
     init(
         coordinator: Coordinator,
-        deactivateUserUseCase: DeactivateUserUseCase,
+        deactivateUserUseCase: DeactivateUserUseCase
     ) {
         self.coordinator = coordinator
         self.deactivateUserUseCase = deactivateUserUseCase


### PR DESCRIPTION
## 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 

- 아카데미 출입증 촬영 시 오류 발생할 때 ServiceAlert 띄워주도록 추가하였습니다.

- DiverCollection 리스트 조회 API ResModel 이 잘못되어 있어 해당 이슈를 수정하였습니다.
  - 기존에 DiverProfileResModel 배열로 받아오고 있었고, 현재 새로 작성한 CollectedDiverResModel 배열로 받아오도록 수정하였습니다.

- Collected Diver Count 를 로컬에 저장하도록 로직을 수정하였습니다.
  - Count 가 필요한 경우 아래와 같이 사용해주세요.
```Swift
let collectedUserCount = LocalUserData.collectedUserCount
```

- Privacy Policy 를 외부 링크를 타고 가도록 수정함에 따라 Navigation Path 에서 제거하였습니다.
