### PR TITLE
Feature/내 프로필 로직 및 UI 구현 완료

### DIFF
--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -9,7 +9,8 @@ struct DiverBookIOSApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationStack(path: self.$coordinator.path) {
-                OnboardingView(coordinator: self.coordinator)
+//                OnboardingView(coordinator: self.coordinator)
+                LoginView(nickname: "Jun", coordinator: self.coordinator)
                     .toolbar(.hidden, for: .navigationBar)
                     .navigationDestination(
                         for: Path.self,

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -9,8 +9,7 @@ struct DiverBookIOSApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationStack(path: self.$coordinator.path) {
-//                OnboardingView(coordinator: self.coordinator)
-                LoginView(nickname: "Jun", coordinator: self.coordinator)
+                OnboardingView(coordinator: self.coordinator)
                     .toolbar(.hidden, for: .navigationBar)
                     .navigationDestination(
                         for: Path.self,

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/DiverProfileEndpoint.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/DiverProfileEndpoint.swift
@@ -10,43 +10,64 @@ import Foundation
 enum DiverProfileEndpoint: Endpoint {
     case myProfile
     case diverProfile(id: String)
-    
+    case updateMyProfile(
+        divisions: String,
+        phoneNumber: String,
+        interests: String,
+        places: String,
+        about: String,
+    )
+
     var path: String {
         switch self {
         case .myProfile:
             return "/api/users/me"
         case .diverProfile(let id):
             return "/api/users/\(id)"
+        case .updateMyProfile:
+            return "/api/users/me"
         }
     }
-    
+
     var method: RequestMethod {
         switch self {
-        default:
+        case .myProfile, .diverProfile:
             return .get
+        case .updateMyProfile:
+            return .patch
         }
     }
-    
+
     var query: [String: String]? {
         switch self {
         default:
             return nil
         }
     }
-    
+
     var header: [String: String]? {
         switch self {
         default:
             return [
                 "accept": "*/*",
                 "Content-Type": "application/json",
-                "Authorization": "\(UserToken.tokenType) \(UserToken.accessToken)"
+                "Authorization":
+                    "\(UserToken.tokenType) \(UserToken.accessToken)",
             ]
         }
     }
-    
+
     var body: [String: String]? {
         switch self {
+        case .updateMyProfile(let params):
+            return [
+                "divisions": params.divisions,
+                "phoneNumber": params.phoneNumber,
+                "interests": params.interests,
+                "places": params.places,
+                "about": params.about,
+
+            ]
         default:
             return nil
         }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/ResponseModels/DiverProfileResModel+Mapping.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/ResponseModels/DiverProfileResModel+Mapping.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct DiverProfileResModel: Decodable {
+struct DiverProfileResModel: Codable {
     var id: String
     var userName: String
     var divisions: String?

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/DiverProfileService.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/DiverProfileService.swift
@@ -21,4 +21,23 @@ final class DiverProfileService: DiverProfileServicable {
             responseModel: BaseResponse<DiverProfileResModel>.self
         )
     }
+    
+    func updateMyProfile(
+        divisions: String,
+        phoneNumber: String,
+        interests: String,
+        places: String,
+        about: String
+    ) async -> Result<BaseResponse<DiverProfileResModel>, RequestError> {
+        return await request(
+            endpoint: DiverProfileEndpoint.updateMyProfile(
+                divisions: divisions,
+                phoneNumber: phoneNumber,
+                interests: interests,
+                places: places,
+                about: about
+            ),
+            responseModel: BaseResponse<DiverProfileResModel>.self
+        )
+    }
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/DefaultBadgeRepository.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/DefaultBadgeRepository.swift
@@ -14,7 +14,7 @@ final class DefaultBadgeRepository: BadgeRepository {
         self.badgeService = badgeService
     }
 
-    func fetchAllBadges() async throws -> [Badge] {
+    func fetchBadges() async throws -> [Badge] {
         async let allBadgesResult = badgeService.fetchBadges()
         async let userBadgesResult = badgeService.fetchUserBadges()
 

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/DefaultDiverRepository.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/DefaultDiverRepository.swift
@@ -7,14 +7,14 @@
 
 final class DefaultDiverRepository: DiverRepository {
     private let diverProfileService: DiverProfileServicable
-    
+
     init(diverProfileService: DiverProfileServicable) {
         self.diverProfileService = diverProfileService
     }
-    
+
     func fetchDiverProfile(id: String) async -> Result<DiverProfile, Error> {
         let profileResult = await diverProfileService.fetchDiverProfile(id: id)
-        
+
         switch profileResult {
         case .success(let baseResponse):
             if baseResponse.success, let data = baseResponse.data {
@@ -28,18 +28,50 @@ final class DefaultDiverRepository: DiverRepository {
             return .failure(error)
         }
     }
-    
+
     func fetchMyProfile() async -> Result<DiverProfile, Error> {
         let myProfileResult = await diverProfileService.fetchMyProfile()
-        
+
         switch myProfileResult {
         case .success(let baseResponse):
             if baseResponse.success, let data = baseResponse.data {
                 let myProfile = data.toDomain()
                 return .success(myProfile)
+            } else {
+                return .failure(
+                    RequestError.errorWithLog(baseResponse.errorMessage ?? "")
+                )
             }
-            else {
-                return .failure(RequestError.errorWithLog(baseResponse.errorMessage ?? ""))
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    func updateMyProfile(
+        divisions: String,
+        phoneNumber: String,
+        interests: String,
+        places: String,
+        about: String
+    ) async -> Result<DiverProfile, Error> {
+        let updateMyResult = await diverProfileService.updateMyProfile(
+            divisions: divisions,
+            phoneNumber: phoneNumber,
+            interests: interests,
+            places: places,
+            about: about
+        )
+
+        switch updateMyResult {
+        case .success(let baseResponse):
+            if baseResponse.success, let data = baseResponse.data {
+                return .success(data.toDomain())
+            } else {
+                return .failure(
+                    RequestError.errorWithLog(
+                        baseResponse.errorMessage ?? "Unknown error"
+                    )
+                )
             }
         case .failure(let error):
             return .failure(error)

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/DiverProfileServicable.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/DiverProfileServicable.swift
@@ -11,4 +11,12 @@ protocol DiverProfileServicable: HTTPClient {
     ) async -> Result<BaseResponse<DiverProfileResModel>, RequestError>
     
     func fetchMyProfile() async -> Result<BaseResponse<DiverProfileResModel>, RequestError>
+    
+    func updateMyProfile(
+           divisions: String,
+           phoneNumber: String,
+           interests: String,
+           places: String,
+           about: String
+       ) async -> Result<BaseResponse<DiverProfileResModel>, RequestError>
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/BadgeRepository.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/BadgeRepository.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol BadgeRepository {
-    func fetchAllBadges() async throws -> [Badge]
+    func fetchBadges() async throws -> [Badge]
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/DiverRepository.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/DiverRepository.swift
@@ -8,4 +8,11 @@
 protocol DiverRepository {
     func fetchDiverProfile(id: String) async -> Result<DiverProfile, Error>
     func fetchMyProfile() async -> Result<DiverProfile, Error>
+    func updateMyProfile(
+        divisions: String,
+        phoneNumber: String,
+        interests: String,
+        places: String,
+        about: String
+    ) async -> Result<DiverProfile, Error>
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/FetchBadgeUseCase/DefaultFetchBadgesUseCase.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/FetchBadgeUseCase/DefaultFetchBadgesUseCase.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 final class DefaultFetchBadgesUseCase: FetchBadgesUseCase {
-    private let repository: BadgeRepository
+    private let badgeRepository: BadgeRepository
 
-    init(repository: BadgeRepository) {
-        self.repository = repository
+    init(badgeRepository: BadgeRepository) {
+        self.badgeRepository = badgeRepository
     }
 
-    func execute() async throws -> [Badge] {
-        try await repository.fetchAllBadges()
+    func executeFetchBadges() async throws -> [Badge] {
+        try await badgeRepository.fetchBadges()
     }
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/FetchBadgeUseCase/FetchBadgeUseCase.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/FetchBadgeUseCase/FetchBadgeUseCase.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol FetchBadgesUseCase {
-    func execute() async throws -> [Badge]
+    func executeFetchBadges() async throws -> [Badge]
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/UpdateMyProfileUseCase/DefaultUpdateMyProfileUseCase.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/UpdateMyProfileUseCase/DefaultUpdateMyProfileUseCase.swift
@@ -1,0 +1,32 @@
+//
+//  DefaultUpdateMyProfileUseCase.swift
+//  DiverBook_iOS
+//
+//  Created by jun on 5/10/25.
+//
+
+import Foundation
+
+final class DefaultUpdateMyProfileUseCase: UpdateMyProfileUseCase {
+    private let repository: DiverRepository
+
+    init(repository: DiverRepository) {
+        self.repository = repository
+    }
+
+    func execute(
+        divisions: String,
+        phoneNumber: String,
+        interests: String,
+        places: String,
+        about: String
+    ) async -> Result<DiverProfile, Error> {
+        return await repository.updateMyProfile(
+            divisions: divisions,
+            phoneNumber: phoneNumber,
+            interests: interests,
+            places: places,
+            about: about
+        )
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/UpdateMyProfileUseCase/UpdateMyProfileUseCase.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/UpdateMyProfileUseCase/UpdateMyProfileUseCase.swift
@@ -1,0 +1,18 @@
+//
+//  UpdateMyProfileUseCase.swift
+//  DiverBook_iOS
+//
+//  Created by jun on 5/10/25.
+//
+
+import Foundation
+
+protocol UpdateMyProfileUseCase {
+    func execute(
+        divisions: String,
+        phoneNumber: String,
+        interests: String,
+        places: String,
+        about: String
+    ) async -> Result<DiverProfile, Error>
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/CollectedBadgeScene/View/CollectedBadgeView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/CollectedBadgeScene/View/CollectedBadgeView.swift
@@ -13,7 +13,7 @@ struct CollectedBadgeView: View {
 
     init() {
         let fetchBadgesUseCase = DefaultFetchBadgesUseCase(
-            repository: DefaultBadgeRepository(
+            badgeRepository: DefaultBadgeRepository(
                 badgeService: BadgeService()
             )
         )

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/CollectedBadgeScene/ViewModel/CollectedBadgeViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/CollectedBadgeScene/ViewModel/CollectedBadgeViewModel.swift
@@ -29,19 +29,20 @@ class CollectedBadgeViewModel: ViewModelable {
     func action(_ action: Action) {
         switch action {
         case .fetchBadges:
-            loadBadges()
+            loadAllBadges()
         }
     }
 
-    private func loadBadges() {
+    private func loadAllBadges() {
         Task {
             do {
-                let badges = try await fetchBadgesUseCase.execute()
+                let allBadgeModels = try await fetchBadgesUseCase.executeFetchBadges()
+                let allBadges = allBadgeModels
                 await MainActor.run {
-                    self.state.badges = badges
+                    self.state.badges = allBadges
                 }
             } catch {
-                print("❌ Failed to load badges: \(error)")
+                print("❌ Failed to load all badges: \(error)")
             }
         }
     }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/View/SubView/ProfileDetailsView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/View/SubView/ProfileDetailsView.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct ProfileDetailsInfoView: View {
-    var division: ProfileInfoMode
-    var phoneNumber: ProfileInfoMode
-    var interests: ProfileInfoMode
-    var places: ProfileInfoMode
+    let division: ProfileInfoMode
+    let phoneNumber: ProfileInfoMode
+    let interests: ProfileInfoMode
+    let places: ProfileInfoMode
 
     var body: some View {
         VStack(spacing: 32) {
@@ -23,11 +23,3 @@ struct ProfileDetailsInfoView: View {
     }
 }
 
-#Preview {
-    ProfileDetailsInfoView(
-        division: .readOnly(text: "디자인"),
-        phoneNumber: .readOnly(text: "010-0000-0000"),
-        interests: .readOnly(text: "사진"),
-        places: .readOnly(text: "C5")
-    )
-}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/View/MyProfileView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/View/MyProfileView.swift
@@ -29,13 +29,16 @@ struct MyProfileView: View {
                 diverProfileService: DiverProfileService()
             )
         )
+        
+        let fetchBadgeUseCase = DefaultFetchBadgesUseCase(badgeRepository: DefaultBadgeRepository(badgeService: BadgeService()))
 
         _viewModel = StateObject(
             wrappedValue: MyProfileViewModel(
                 coordinator: coordinator,
                 fetchDiverProfileUseCase: fetchDiverProfileUseCase,
                 fetchRefreshTokenUseCase: fetchRefreshTokenUseCase,
-                updateMyProfileUseCase: updateMyProfileUseCase
+                updateMyProfileUseCase: updateMyProfileUseCase,
+                fetchBadgeUseCase: fetchBadgeUseCase
             )
         )
     }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/View/MyProfileView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/View/MyProfileView.swift
@@ -48,6 +48,11 @@ struct MyProfileView: View {
                 ScrollView(showsIndicators: false) {
                     MyProfileContentView(
                         myProfile: $viewModel.state.myProfile,
+                        todayTalk: $viewModel.state.todayTalk,
+                        division: $viewModel.state.division,
+                        phoneNumber: $viewModel.state.phoneNumber,
+                        interests: $viewModel.state.interests,
+                        places: $viewModel.state.places,
                         badgeCount: viewModel.state.badgeCount,
                         onCollectedBadgeTap: {
                             viewModel.action(.tapCollectedBadge)
@@ -59,6 +64,11 @@ struct MyProfileView: View {
                 ScrollView(showsIndicators: false) {
                     MyProfileContentView(
                         myProfile: $viewModel.state.myProfile,
+                        todayTalk: $viewModel.state.todayTalk,
+                        division: $viewModel.state.division,
+                        phoneNumber: $viewModel.state.phoneNumber,
+                        interests: $viewModel.state.interests,
+                        places: $viewModel.state.places,
                         badgeCount: viewModel.state.badgeCount,
                         onCollectedBadgeTap: {
                             viewModel.action(.tapCollectedBadge)

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/View/MyProfileView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/View/MyProfileView.swift
@@ -9,30 +9,37 @@ import SwiftUI
 
 struct MyProfileView: View {
     @StateObject private var viewModel: MyProfileViewModel
-    
+
     init(coordinator: Coordinator) {
         let fetchDiverProfileUseCase = DefaultFetchDiverProfileUseCase(
             repository: DefaultDiverRepository(
                 diverProfileService: DiverProfileService()
             )
         )
-        
+
         let fetchRefreshTokenUseCase = DefaultFetchRefreshTokenUseCase(
             repository: DefaultAuthRepository(
                 authService: DiverBookAuthService(),
                 tokenService: DiverBookTokenService()
             )
         )
-        
+
+        let updateMyProfileUseCase = DefaultUpdateMyProfileUseCase(
+            repository: DefaultDiverRepository(
+                diverProfileService: DiverProfileService()
+            )
+        )
+
         _viewModel = StateObject(
             wrappedValue: MyProfileViewModel(
                 coordinator: coordinator,
                 fetchDiverProfileUseCase: fetchDiverProfileUseCase,
-                fetchRefreshTokenUseCase: fetchRefreshTokenUseCase
+                fetchRefreshTokenUseCase: fetchRefreshTokenUseCase,
+                updateMyProfileUseCase: updateMyProfileUseCase
             )
         )
     }
-    
+
     var body: some View {
         VStack {
             MyProfileTopBarView()

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/View/SubView/MyProfileContentView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/View/SubView/MyProfileContentView.swift
@@ -10,6 +10,11 @@ import SwiftUI
 
 struct MyProfileContentView: View {
     @Binding var myProfile: DiverProfile
+    @Binding var todayTalk: String
+    @Binding var division: String
+    @Binding var phoneNumber: String
+    @Binding var interests: String
+    @Binding var places: String
     let badgeCount: Int
     let onCollectedBadgeTap: () -> Void
 
@@ -28,7 +33,7 @@ struct MyProfileContentView: View {
 
                 TodayTalkSectionView(
                     mode: .editable(
-                        binding: $myProfile.about
+                        binding: $todayTalk
                     )
                 )
                 .padding(.horizontal, 4)
@@ -36,20 +41,12 @@ struct MyProfileContentView: View {
                 Spacer().frame(height: 40)
 
                 ProfileDetailsInfoView(
-                    division: .editable(
-                        binding: $myProfile.divisions
-                    ),
-                    phoneNumber: .editable(
-                        binding: $myProfile.phoneNumber
-                    ),
-                    interests: .editable(
-                        binding: $myProfile.interests
-                    ),
-                    places: .editable(
-                        binding: $myProfile.places
-                    )
+                    division: .editable(binding: $division),
+                    phoneNumber: .editable(binding: $phoneNumber),
+                    interests: .editable(binding: $interests),
+                    places: .editable(binding: $places)
                 )
-
+                
                 Spacer().frame(height: 14)
 
                 CollectedBadgeButtonView(

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/ViewModel/MyProfileViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/ViewModel/MyProfileViewModel.swift
@@ -11,39 +11,31 @@ import SwiftUI
 
 final class MyProfileViewModel: ViewModelable {
     struct State {
-        var isDataFetching : Bool = false
+        var isDataFetching: Bool = false
         var myProfile: DiverProfile = DiverProfile.mockData
-        
+
         var todayTalk: String = ""
         var division: String = ""
         var phoneNumber: String = ""
         var interests: String = ""
         var places: String = ""
         var badgeCount: Int = 0
-        var nickname: String = ""
-        
+
         var errorMessage: String = ""
         var isErrorShowing: Bool = false
-        
     }
 
     enum Action {
         case viewAppeared
-        case updateTodayTalk(String)
-        case updateDivision(String)
-        case updatePhoneNumber(String)
-        case updateInterests(String)
-        case updatePlaces(String)
         case tapCollectedBadge
     }
 
     @Published var state = State()
-    
     @ObservedObject var coordinator: Coordinator
 
     private var cancellables = Set<AnyCancellable>()
-    
-    //UseCases
+
+    // UseCases
     private let fetchDiverProfileUseCase: FetchDiverProfileUseCase
     private let fetchRefreshTokenUseCase: FetchRefreshTokenUseCase
     private var updateMyProfileUseCase: UpdateMyProfileUseCase
@@ -65,20 +57,10 @@ final class MyProfileViewModel: ViewModelable {
         switch action {
         case .viewAppeared:
             state.isDataFetching = true
-            Task{
+            Task {
                 await fetchMyProfile()
                 state.isDataFetching = false
             }
-        case .updateTodayTalk(let newTalk):
-            state.todayTalk = newTalk
-        case .updateDivision(let newDivision):
-            state.division = newDivision
-        case .updatePhoneNumber(let newPhoneNumber):
-            state.phoneNumber = newPhoneNumber
-        case .updateInterests(let newInterests):
-            state.interests = newInterests
-        case .updatePlaces(let newPlaces):
-            state.places = newPlaces
         case .tapCollectedBadge:
             coordinator.push(.collectedBadge)
         }
@@ -95,7 +77,12 @@ final class MyProfileViewModel: ViewModelable {
         switch myProfileResult {
         case .success(let profile):
             state.myProfile = profile
-        case .failure(let error):
+            state.todayTalk = profile.about
+            state.division = profile.divisions
+            state.phoneNumber = profile.phoneNumber
+            state.interests = profile.interests
+            state.places = profile.places
+        case .failure:
             activateErrorAlert(message: "사용자 정보 조회에 실패하였습니다.")
         }
     }
@@ -104,17 +91,31 @@ final class MyProfileViewModel: ViewModelable {
         $state
             .dropFirst()
             .debounce(for: .milliseconds(500), scheduler: RunLoop.main)
-            .sink { [weak self] newState in
+            .sink { [weak self] _ in
                 self?.updateProfile()
             }
             .store(in: &cancellables)
     }
 
     private func updateProfile() {
-        // TODO: PATCH 로직 연결 필요 (예: UpdateProfileUseCase)
-        print("✅ 자동 저장 요청 준비됨")
+        Task {
+            let result = await updateMyProfileUseCase.execute(
+                divisions: state.division,
+                phoneNumber: state.phoneNumber,
+                interests: state.interests,
+                places: state.places,
+                about: state.todayTalk
+            )
+
+            switch result {
+            case .success:
+                print("✅ 프로필 업데이트 성공")
+            case .failure(let error):
+                print("❌ 프로필 업데이트 실패: \(error)")
+            }
+        }
     }
-    
+
     private func activateErrorAlert(message: String) {
         state.errorMessage = message
         state.isErrorShowing = true

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/ViewModel/MyProfileViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MyProfileScene/ViewModel/MyProfileViewModel.swift
@@ -46,15 +46,18 @@ final class MyProfileViewModel: ViewModelable {
     //UseCases
     private let fetchDiverProfileUseCase: FetchDiverProfileUseCase
     private let fetchRefreshTokenUseCase: FetchRefreshTokenUseCase
+    private var updateMyProfileUseCase: UpdateMyProfileUseCase
 
     init(
         coordinator: Coordinator,
         fetchDiverProfileUseCase: FetchDiverProfileUseCase,
-        fetchRefreshTokenUseCase: FetchRefreshTokenUseCase
+        fetchRefreshTokenUseCase: FetchRefreshTokenUseCase,
+        updateMyProfileUseCase: UpdateMyProfileUseCase
     ) {
         self.coordinator = coordinator
         self.fetchDiverProfileUseCase = fetchDiverProfileUseCase
         self.fetchRefreshTokenUseCase = fetchRefreshTokenUseCase
+        self.updateMyProfileUseCase = updateMyProfileUseCase
         observeStateChanges()
     }
 


### PR DESCRIPTION
## 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.

- CollectedBadgeViewModel 내부에서 모든 뱃지 데이터를 `GET /api/badges`로 불러오고, 유저가 획득한 뱃지 데이터를 `GET /api/user-badge`로 받아와 `isCollected = true`인 경우만 이미지로 표시되도록 로직 수정
- 유저가 수집한 뱃지 수를 `GET /api/user-badge` 응답에서 개수로 계산하여 MyProfile에 표시
- MyProfileView에서 내 프로필 정보를 수정하면 서버에 자동으로 저장되도록 `updateMyProfile` 로직 구현 및 연동

## 📌 PR 특이사항

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.

### 특이 사항 1
- Air에게 badgeCode를 강제로 넣어달라고 요청하여 테스트해볼 예정입니다. 현재 POST `/api/user-badge` 부분이 구현되지 않아 badgeCode를 보유하고 있는지 여부에 대한 정상적인 테스트는 불가능한 상태입니다.

### 특이 사항 2
- 서버에는 프로필 정보가 정상적으로 저장되지만, 클라이언트에서는 `decode` 관련 오류 로그가 발생합니다. QA 시점에 원인 분석이 필요합니다.  
  <img width="1512" alt="스크린샷" src="https://github.com/user-attachments/assets/8fe62ef5-ecae-4cdd-bfa1-8fcc874b3a54" />

