### PR TITLE
[feat] 메인 탭에서 프로필 관리 버튼 탭 시 내 프로필 페이지로 이동하는 로직 추가

### DIFF
--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/DiverProfileEndpoint.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/DiverProfileEndpoint.swift
@@ -15,7 +15,7 @@ enum DiverProfileEndpoint: Endpoint {
         phoneNumber: String,
         interests: String,
         places: String,
-        about: String,
+        about: String
     )
 
     var path: String {

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MainScene/ViewModel/MainViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/MainScene/ViewModel/MainViewModel.swift
@@ -66,7 +66,7 @@ final class MainViewModel: ViewModelable {
             }
             
         case .profileSettingButtonTapped:
-            print("profile setting button tapped!")
+            coordinator.push(.myProfile)
         case .collectionDiverTapped(let diverId):
             if state.isFoundedDiver[diverId] ?? false {
                 coordinator.push(.diverProfile(id: diverId))


### PR DESCRIPTION
메인 탭에서 프로필 관리 버튼 탭 시 내 프로필 페이지로 이동하는 로직을 추가하였습니다.

## 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 

메인 화면에서 프로필 관리 버튼 탭 시 내 프로필 페이지로 이동하는 로직을 추가하였습니다.
