### PR TITLE
[Feat] 뱃지 획득 화면 로직 구현

### DIFF
--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/Coordinator.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/Coordinator.swift
@@ -37,4 +37,5 @@ enum Path: Hashable {
     case myProfile
     case diverProfile(id: String)
     case collectedBadge
+    case badgeReward(badgeCode: String)
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -9,7 +9,8 @@ struct DiverBookIOSApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationStack(path: self.$coordinator.path) {
-                OnboardingView(coordinator: self.coordinator)
+//                OnboardingView(coordinator: self.coordinator)
+                LoginView(nickname: "Jun", coordinator: self.coordinator)
                     .toolbar(.hidden, for: .navigationBar)
                     .navigationDestination(
                         for: Path.self,

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -74,6 +74,8 @@ struct DiverBookIOSApp: App {
                                     mode: .edit
                                 )
                                     .toolbar(.hidden, for: .navigationBar)
+                            case .badgeReward(badgeCode: let badgeCode):
+                                BadgeRewardView(coordinator: self.coordinator, badgeCode: badgeCode)
                             }
                         })
             }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -9,8 +9,7 @@ struct DiverBookIOSApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationStack(path: self.$coordinator.path) {
-//                OnboardingView(coordinator: self.coordinator)
-                LoginView(nickname: "Jun", coordinator: self.coordinator)
+                OnboardingView(coordinator: self.coordinator)
                     .toolbar(.hidden, for: .navigationBar)
                     .navigationDestination(
                         for: Path.self,

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/BadgeEndpoint.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/BadgeEndpoint.swift
@@ -10,6 +10,7 @@ import Foundation
 enum BadgeEndpoint: Endpoint {
     case getBadges
     case getUserBadges
+    case postUserBadge(badgeCode: String)
 }
 
 extension BadgeEndpoint {
@@ -19,15 +20,17 @@ extension BadgeEndpoint {
             return "/api/badges"
         case .getUserBadges:
             return "/api/user-badge"
+        case .postUserBadge(let badgeCode):
+            return "/api/user-badge/\(badgeCode)"
         }
     }
 
     var method: RequestMethod {
         switch self {
-        case .getBadges:
+        case .getBadges, .getUserBadges:
             return .get
-        case .getUserBadges:
-            return .get
+        case .postUserBadge:
+            return .post
         }
     }
 

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/BadgeService.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/BadgeService.swift
@@ -25,4 +25,11 @@ final class BadgeService: BadgeServicable {
             responseModel: BaseResponse<[UserBadgeResponseModel]>.self
         )
     }
+    
+    func postUserBadge(badgeCode: String) async -> Result<UserBadgeResponseModel, RequestError> {
+        return await request(
+            endpoint: BadgeEndpoint.postUserBadge(badgeCode: badgeCode),
+            responseModel: UserBadgeResponseModel.self
+        )
+    }
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/DefaultBadgeRepository.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/DefaultBadgeRepository.swift
@@ -25,4 +25,15 @@ final class DefaultBadgeRepository: BadgeRepository {
             $0.toDomain(isCollected: userBadgeCodes.contains($0.code))
         }
     }
+    
+    func postUserBadge(badgeCode: String) async throws -> String {
+        let result = await badgeService.postUserBadge(badgeCode: badgeCode)
+        
+        switch result {
+        case .success(let badgeCode):
+            return badgeCode.toDomain()
+        case .failure(let error):
+            throw error
+        }
+    }
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/BadgeServicable.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/BadgeServicable.swift
@@ -10,4 +10,5 @@ import Foundation
 protocol BadgeServicable: HTTPClient {
     func fetchBadges() async -> Result<BaseResponse<[BadgeResponseModel]>, RequestError>
     func fetchUserBadges() async -> Result<BaseResponse<[UserBadgeResponseModel]>, RequestError>
+    func postUserBadge(badgeCode: String) async -> Result<UserBadgeResponseModel, RequestError>
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/BadgeRepository.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/BadgeRepository.swift
@@ -9,4 +9,5 @@ import Foundation
 
 protocol BadgeRepository {
     func fetchBadges() async throws -> [Badge]
+    func postUserBadge(badgeCode: String) async throws -> String
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/PostUserBadgeUseCase/DefaultPostUserBadgeUseCase.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/PostUserBadgeUseCase/DefaultPostUserBadgeUseCase.swift
@@ -1,0 +1,21 @@
+//
+//  DefaultPostUserBadgeUseCase.swift
+//  DiverBook_iOS
+//
+//  Created by jun on 5/12/25.
+//
+
+import Foundation
+
+final class DefaultPostUserBadgeUseCase: PostUserBadgeUseCase {
+    
+    private let badgeRepository: BadgeRepository
+
+    init(badgeRepository: BadgeRepository) {
+        self.badgeRepository = badgeRepository
+    }
+
+    func executePostUserBadge(badgeCode: String) async throws -> String {
+        return try await badgeRepository.postUserBadge(badgeCode: badgeCode)
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/PostUserBadgeUseCase/PostUserBadgeUseCase.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/PostUserBadgeUseCase/PostUserBadgeUseCase.swift
@@ -1,0 +1,12 @@
+//
+//  PostUserBadgeUseCase.swift
+//  DiverBook_iOS
+//
+//  Created by jun on 5/12/25.
+//
+
+import Foundation
+
+protocol PostUserBadgeUseCase {
+    func executePostUserBadge(badgeCode: String) async throws -> String
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/BadgeRewardScene/View/BadgeRewardView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/BadgeRewardScene/View/BadgeRewardView.swift
@@ -8,26 +8,31 @@
 import SwiftUI
 
 struct BadgeRewardView: View {
-    @StateObject var viewModel: BadenRewardViewModel
+    @StateObject private var viewModel: BadenRewardViewModel
 
-    init(coordinator: Coordinator) {
+    init(coordinator: Coordinator, badgeCode: String) {
         _viewModel = StateObject(
-            wrappedValue: BadenRewardViewModel(coordinator: coordinator)
+            wrappedValue: BadenRewardViewModel(coordinator: coordinator, badgeCode: badgeCode)
         )
     }
 
     var body: some View {
         VStack {
             Spacer()
-            
-            Image(viewModel.state.badge)
-                .resizable()
-                .scaledToFit()
-                .frame(width: 125, height: 177)
-                .applyShadow(DiveShadow.shadow1)
+
+            if let imageURL = URL(string: viewModel.state.badgeImage) {
+                AsyncImage(url: imageURL) { image in
+                    image.resizable()
+                         .scaledToFit()
+                         .frame(width: 125, height: 177)
+                         .applyShadow(DiveShadow.shadow1)
+                } placeholder: {
+                    ProgressView()
+                        .frame(width: 125, height: 177)
+                }
+            }
 
             VStack(spacing: 4) {
-                Text("다이버시티에서 \(viewModel.state.badgeDescription)!")
                 HStack {
                     Text("'\(viewModel.state.badgeName)'")
                         .foregroundStyle(DiveColor.color6)
@@ -35,7 +40,7 @@ struct BadgeRewardView: View {
                 }
             }
             .font(DiveFont.headingH3)
-            
+
             Spacer()
 
             PrimaryButton(title: "확인", coordinator: viewModel.coordinator) {
@@ -43,9 +48,8 @@ struct BadgeRewardView: View {
             }
         }
         .padding(.horizontal, 24)
+        .onAppear {
+            viewModel.loadBadge()
+        }
     }
-}
-
-#Preview {
-    BadgeRewardView(coordinator: Coordinator())
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/BadgeRewardScene/ViewModel/BadenRewardViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/BadgeRewardScene/ViewModel/BadenRewardViewModel.swift
@@ -59,7 +59,7 @@ class BadenRewardViewModel: ObservableObject {
     func action(_ action: Action) {
         switch action {
         case .confirmButtonTapped:
-            coordinator.push(.collectedBadge)
+            coordinator.path = [.mainTab]
         }
     }
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/BadgeRewardScene/ViewModel/BadenRewardViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/BadgeRewardScene/ViewModel/BadenRewardViewModel.swift
@@ -10,20 +10,50 @@ import SwiftUI
 
 class BadenRewardViewModel: ObservableObject {
     struct State {
-        var badge = "badge1"
-        var badgeName = "첫 입수"
-        var badgeDescription = "첫 다이버 등록"
+        var badgeImage: String = ""
+        var badgeName: String = ""
     }
 
     enum Action {
         case confirmButtonTapped
     }
 
-    @Published var state: State = State()
+    @Published var state = State()
     @ObservedObject var coordinator: Coordinator
 
-    init(coordinator: Coordinator) {
+    private let badgeCode: String
+    private let fetchBadgesUseCase: FetchBadgesUseCase
+
+    init(
+        coordinator: Coordinator,
+        badgeCode: String,
+        fetchBadgesUseCase: FetchBadgesUseCase = DefaultFetchBadgesUseCase(
+            badgeRepository: DefaultBadgeRepository(
+                badgeService: BadgeService()
+            )
+        )
+    ) {
         self.coordinator = coordinator
+        self.badgeCode = badgeCode
+        self.fetchBadgesUseCase = fetchBadgesUseCase
+    }
+
+    func loadBadge() {
+        Task {
+            do {
+                let badges = try await fetchBadgesUseCase.executeFetchBadges()
+                if let matched = badges.first(where: { $0.code == badgeCode }) {
+                    await MainActor.run {
+                        state = State(
+                            badgeImage: matched.imageUrl,
+                            badgeName: matched.name,
+                        )
+                    }
+                }
+            } catch {
+                print("❌ 뱃지 로딩 실패: \(error)")
+            }
+        }
     }
 
     func action(_ action: Action) {

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/CollectedBadgeScene/View/SubView/BadgeCardView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/CollectedBadgeScene/View/SubView/BadgeCardView.swift
@@ -12,7 +12,11 @@ struct BadgeCardView: View {
     let onTap: () -> Void
 
     var body: some View {
-        Button(action: onTap) {
+        Button {
+            if badge.isCollected {
+                onTap()
+            }
+        } label: {
             VStack(spacing: 8) {
                 if badge.isCollected, let url = URL(string: badge.imageUrl) {
                     AsyncImage(url: url) { phase in
@@ -53,7 +57,7 @@ struct BadgeCardView: View {
             .frame(height: 150)
             .background(DiveColor.white)
             .cornerRadius(8)
-            .shadow(color: .black.opacity(0.15), radius: 5, x: 0, y: 2)
+            .applyShadow(DiveShadow.shadow1)
         }
     }
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/View/DiverProfileView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/View/DiverProfileView.swift
@@ -34,6 +34,8 @@ struct DiverProfileView: View {
                 diverCollectionService: DiverCollectionService()
             )
         )
+        
+        let postUserBadgeUseCase = DefaultPostUserBadgeUseCase(badgeRepository: DefaultBadgeRepository(badgeService: BadgeService()))
 
         _viewModel = StateObject(
             wrappedValue: DiverProfileViewModel(
@@ -43,6 +45,7 @@ struct DiverProfileView: View {
                 fetchDIverCollectionUseCase: fetchDiverCollectionUsecase,
                 updateDiverMemoUseCase: updateDiverMemoUseCase,
                 saveDiverMemoUseCase: saveDiverMemoUseCase,
+                postUserBadgeUseCase: postUserBadgeUseCase,
                 diverId: diverId
             )
         )

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/ViewModel/DiverProfileViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/ViewModel/DiverProfileViewModel.swift
@@ -37,6 +37,7 @@ final class DiverProfileViewModel: ViewModelable {
     private let fetchDiverCollectionUseCase: DiverCollectionUseCase
     private let updateDiverMemoUseCase: UpdateDiverMemoUseCase
     private let saveDiverMemoUseCase: SaveDiverMemoUseCase
+    private let postUserBadgeUseCase: PostUserBadgeUseCase
     
     init(
         coordinator: Coordinator,
@@ -45,6 +46,7 @@ final class DiverProfileViewModel: ViewModelable {
         fetchDIverCollectionUseCase: DiverCollectionUseCase,
         updateDiverMemoUseCase: UpdateDiverMemoUseCase,
         saveDiverMemoUseCase: SaveDiverMemoUseCase,
+        postUserBadgeUseCase: PostUserBadgeUseCase,
         diverId: String
     ) {
         self.coordinator = coordinator
@@ -53,6 +55,7 @@ final class DiverProfileViewModel: ViewModelable {
         self.fetchDiverCollectionUseCase = fetchDIverCollectionUseCase
         self.updateDiverMemoUseCase = updateDiverMemoUseCase
         self.saveDiverMemoUseCase = saveDiverMemoUseCase
+        self.postUserBadgeUseCase = postUserBadgeUseCase
         self.state.diverId = diverId
     }
 

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/ViewModel/DiverProfileViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/ViewModel/DiverProfileViewModel.swift
@@ -29,7 +29,7 @@ final class DiverProfileViewModel: ViewModelable {
     @Published var state = State()
     @Published var memo: String = ""
     @Published private(set) var isSaveEnabled: Bool = false
-    
+
     private let coordinator: Coordinator
     private let mode: DiverProfileMode
     private var originalMemo: String = ""
@@ -38,7 +38,7 @@ final class DiverProfileViewModel: ViewModelable {
     private let updateDiverMemoUseCase: UpdateDiverMemoUseCase
     private let saveDiverMemoUseCase: SaveDiverMemoUseCase
     private let postUserBadgeUseCase: PostUserBadgeUseCase
-    
+
     init(
         coordinator: Coordinator,
         mode: DiverProfileMode,
@@ -85,10 +85,10 @@ final class DiverProfileViewModel: ViewModelable {
             }
         }
     }
-    
+
     private func fetchDiverProfileById() async {
         let result = await fetchDiverProfileUseCase.executeFetchProfile(id: state.diverId)
-        
+
         await MainActor.run {
             switch result {
             case .success(let profile):
@@ -100,10 +100,10 @@ final class DiverProfileViewModel: ViewModelable {
             state.isDataFetching = false
         }
     }
-    
+
     private func fetchDiverCollectionInfo() async {
         let result = await fetchDiverCollectionUseCase.executeFetchDiverCollection()
-        
+
         await MainActor.run {
             switch result {
             case .success(let collection):
@@ -118,20 +118,52 @@ final class DiverProfileViewModel: ViewModelable {
             }
         }
     }
-    
+
     private func createDiverMemo() async {
         let createResult = await saveDiverMemoUseCase.executeSaveDiverMemoUseCase(
             foundUserId: state.diverId,
             memo: memo
         )
-        
+
         switch createResult {
         case .success(let updated):
             originalMemo = updated.memo
             isSaveEnabled = false
-            // TODO: 뱃지 획득 or 메인 화면으로 이동
-            coordinator.path = [.mainTab]
-            print("✅ POST 성공")
+            print("✅ 메모 POST 성공")
+
+            async let collectedResult = fetchDiverCollectionUseCase.executeFetchDiverCollection()
+            async let allDiverResult = fetchDiverCollectionUseCase.executeFetchAllDiverList()
+
+            do {
+                let collections = try await collectedResult.get()
+                let allDivers = try await allDiverResult.get()
+                let collectedCount = collections.count
+                let totalCount = allDivers.count
+
+                print("🧾 수집한 다이버 수: \(collectedCount), 전체 다이버 수: \(totalCount)")
+
+                if let badgeCode = badgeCodeForCollectionCount(collectedCount, totalCount: totalCount) {
+                    do {
+                        let postedCode = try await postUserBadgeUseCase.executePostUserBadge(badgeCode: badgeCode)
+                        print("🎉 뱃지 POST 성공 - 코드: \(postedCode)")
+                        await MainActor.run {
+                            coordinator.path = [.badgeReward(badgeCode: postedCode)]
+                        }
+                        return
+                    } catch {
+                        print("❌ 뱃지 POST 실패: \(error.localizedDescription)")
+                    }
+                } else {
+                    print("⚠️ 뱃지 조건 불충족")
+                }
+            } catch {
+                print("❌ 도감 조회 실패: \(error.localizedDescription)")
+            }
+
+            await MainActor.run {
+                coordinator.path = [.mainTab]
+            }
+
         case .failure(let error):
             print("❌ POST 실패: \(error)")
         }
@@ -153,17 +185,29 @@ final class DiverProfileViewModel: ViewModelable {
             print("❌ PATCH 실패: \(error)")
         }
     }
-    
+
     private func saveMemo() async {
         switch mode {
         case .create:
             await createDiverMemo()
-
         case .edit:
             await updateDiverMemo()
         }
     }
-    
+
+    private func badgeCodeForCollectionCount(_ collectedCount: Int, totalCount: Int) -> String? {
+        switch collectedCount {
+        case 1: return "B001"
+        case 10: return "B002"
+        case 20: return "B003"
+        case 30: return "B004"
+        case 40: return "B005"
+        case 50: return "B006"
+        case _ where collectedCount == totalCount: return "B007"
+        default: return nil
+        }
+    }
+
     private func formatFoundDate(_ raw: String) -> String {
         let inputFormatter = DateFormatter()
         inputFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"


### PR DESCRIPTION
## 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.

- [x] 뱃지 시스템 전체 플로우 구현  
  - DiverProfile에서 createMemo 시 collection 조건 충족 시 badgeCode 획득  
  - 조건 충족 시 `POST /user-badge/{badgeCode}`로 서버에 저장  
  - 저장 성공 시 `BadgeRewardView`로 이동  
- [x] `BadgeRewardView`는 badgeCode를 외부 주입 받아 뱃지 이미지/정보 로딩  
- [x] `MyProfile`에서 획득한 뱃지 개수 로딩 (`GET /user-badge`)  
- [x] `CollectedBadgeView`에서 획득하지 않은 뱃지는 탭 비활성 처리  
- [x] `BadgeCardView`에서 `badge.isCollected == false`일 경우 `onTap()` 차단  

## 📌 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
- 다이버 프로필 저장 → 다이버 수 조건 만족 → 뱃지 획득 → 뱃지획득 시 BadgeRewardView 이동 → 확인 버튼 클릭시 → 메인 뷰로 이동
- 다이버 프로필 저장 → 뱃지 미획득 → 메인뷰로 이동
- 다이버 탐색 후 다이버 수를 만족하는 조건을 달성해야 뱃지를 얻는데, 해당 파트는 혼자 테스트하는 것이 불가능하여 테스팅은 못했습니다. QA때 제대로 저장안된다면 수정이 필요해보입니다.