### PR TITLE
[feat] 다이버 탐색 플로우 변경

### DIFF
--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/Coordinator.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/Coordinator.swift
@@ -33,6 +33,7 @@ enum Path: Hashable {
     case unfoundDiver(nickname: String)
     case searchResult(diverProfile: DiverProfile)
     case startConversation(id: String)
+    case checkConversation(id: String)
     case finishConversation(id: String)
     case myProfile
     case diverProfile(id: String)

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -50,6 +50,12 @@ struct DiverBookIOSApp: App {
                             case .startConversation(let diverId):
                                 ConversationView(coordinator: self.coordinator, diverId: diverId)
                                     .toolbar(.hidden, for: .navigationBar)
+                            case .checkConversation(let diverId):
+                                CheckConversationView(
+                                    coordinator: self.coordinator,
+                                    diverId: diverId
+                                )
+                                    .toolbar(.hidden, for: .navigationBar)
                             case .finishConversation(let diverId):
                                 DiverProfileView(
                                     coordinator: self.coordinator,

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/UserDefaults/LocalUserData.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/UserDefaults/LocalUserData.swift
@@ -8,4 +8,7 @@
 struct LocalUserData {
     @UserDefault(key: "collectedUserCount", defaultValue: 0)
     static var collectedUserCount: Int
+    
+    @UserDefault(key: "hasNewDiverProfile", defaultValue: false)
+    static var hasNewDiverProfile: Bool
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/ConversationView/View/CheckConversationView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/ConversationView/View/CheckConversationView.swift
@@ -1,0 +1,54 @@
+//
+//  CheckConversationView.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 5/17/25.
+//
+
+import SwiftUI
+
+struct CheckConversationView: View {
+    @StateObject var viewModel: CheckConversationViewModel
+    
+    init(coordinator: Coordinator, diverId: String) {
+        let saveDiverMemoUseCase = DefaultSaveDiverMemoUseCase(
+            diverCollectionRepository: DefaultDiverCollectionRepository(
+                diverCollectionService: DiverCollectionService()
+            )
+        )
+        
+        _viewModel = StateObject(
+            wrappedValue: CheckConversationViewModel(
+                coordinator: coordinator,
+                diverId: diverId,
+                saveDiverMemoUseCase: saveDiverMemoUseCase
+            )
+        )
+    }
+    
+    var body: some View {
+        VStack(alignment: .center) {
+            TopBar()
+                .padding(.bottom, 50)
+            Text("상대 다이버의\n대화 완료를 기다리는 중이에요")
+                .font(DiveFont.headingH3)
+                .foregroundColor(DiveColor.gray4)
+                .padding(.bottom, 25)
+                .multilineTextAlignment(.center)
+            Text("모두 대화 완료시 도감을 획득할 수 있습니다")
+                .font(DiveFont.bodyMedium1)
+                .foregroundColor(DiveColor.gray4)
+                .multilineTextAlignment(.center)
+            Spacer()
+            ProgressView()
+            Spacer()
+        }
+        .padding(.horizontal, 24)
+        .onAppear {
+            viewModel.action(.sendFinishConversation)
+        }
+        .onDisappear {
+            viewModel.stopSearching()
+        }
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/ConversationView/ViewModel/CheckConversationViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/ConversationView/ViewModel/CheckConversationViewModel.swift
@@ -1,0 +1,82 @@
+//
+//  CheckConversationViewModel.swift
+//  DiverBook_iOS
+//
+//  Created by 배현진 on 5/17/25.
+//
+
+import Combine
+import SwiftUI
+
+final class CheckConversationViewModel: ViewModelable {
+    struct State {
+    }
+    
+    enum Action {
+        case sendFinishConversation
+        case checkFinishConversation(isFinishConversation: String)
+    }
+    
+    @Published var state: State = State()
+    @ObservedObject var coordinator: Coordinator
+    
+    private let userID: String
+    private let diverId: String
+    private let saveDiverMemoUseCase: SaveDiverMemoUseCase
+    private lazy var dataTransferManager: DataTransferManager = {
+        return DataTransferManager(userID: userID, viewModel: self)
+    }()
+    
+    init(
+        coordinator: Coordinator,
+        diverId: String,
+        saveDiverMemoUseCase: SaveDiverMemoUseCase
+    ) {
+        self.userID = UserToken.id
+        self.diverId = diverId
+        self.coordinator = coordinator
+        self.saveDiverMemoUseCase = saveDiverMemoUseCase
+        dataTransferManager.currentMode = .checkConversation
+    }
+    
+    func action(_ action: Action) {
+        switch action {
+        case .sendFinishConversation:
+            dataTransferManager.startSession()
+        case .checkFinishConversation(let flag):
+            checkFinishFlag(isFinishFlag: flag)
+        }
+    }
+    
+    func stopSearching() {
+        dataTransferManager.stopSession()
+    }
+    
+    private func checkFinishFlag(isFinishFlag: String) {
+        if isFinishFlag == "finish" {
+            Task {
+                await createDiverMemo()
+                coordinator.push(.finishConversation(id: diverId))
+            }
+        }
+    }
+    
+    private func createDiverMemo() async {
+        let createResult = await saveDiverMemoUseCase.executeSaveDiverMemoUseCase(
+            foundUserId: diverId,
+            memo: ""
+        )
+
+        switch createResult {
+        case .success(let updated):
+            print("✅ 새로운 도감 정보 저장 성공")
+            await MainActor.run {
+                coordinator.path = [.mainTab]
+            }
+
+        case .failure(let error):
+            print("❌ 새로운 도감 정보 저장 실패: \(error)")
+        }
+    }
+
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/ConversationView/ViewModel/CheckConversationViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/ConversationView/ViewModel/CheckConversationViewModel.swift
@@ -70,6 +70,7 @@ final class CheckConversationViewModel: ViewModelable {
         switch createResult {
         case .success(let updated):
             print("✅ 새로운 도감 정보 저장 성공")
+            LocalUserData.hasNewDiverProfile = true
             await MainActor.run {
                 coordinator.path = [.mainTab]
             }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/ConversationView/ViewModel/ConversationViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/ConversationView/ViewModel/ConversationViewModel.swift
@@ -41,7 +41,7 @@ final class ConversationViewModel: ViewModelable {
     func action(_ action: Action) {
         switch action {
         case .finishConversation(let diverID):
-            coordinator.push(.finishConversation(id: diverID))
+            coordinator.push(.checkConversation(id: diverID))
         case .selectCard(let index):
             handleSelectCard(index: index)
         case .dismissCard:

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/View/DiverProfileView.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/View/DiverProfileView.swift
@@ -29,12 +29,6 @@ struct DiverProfileView: View {
             )
         )
         
-        let saveDiverMemoUseCase = DefaultSaveDiverMemoUseCase(
-            diverCollectionRepository: DefaultDiverCollectionRepository(
-                diverCollectionService: DiverCollectionService()
-            )
-        )
-        
         let postUserBadgeUseCase = DefaultPostUserBadgeUseCase(badgeRepository: DefaultBadgeRepository(badgeService: BadgeService()))
 
         _viewModel = StateObject(
@@ -44,7 +38,6 @@ struct DiverProfileView: View {
                 fetchDiverProfileUseCase: fetchDiverProfileUseCase,
                 fetchDIverCollectionUseCase: fetchDiverCollectionUsecase,
                 updateDiverMemoUseCase: updateDiverMemoUseCase,
-                saveDiverMemoUseCase: saveDiverMemoUseCase,
                 postUserBadgeUseCase: postUserBadgeUseCase,
                 diverId: diverId
             )

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/ViewModel/DiverProfileViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverProfileScene/ViewModel/DiverProfileViewModel.swift
@@ -36,7 +36,6 @@ final class DiverProfileViewModel: ViewModelable {
     private let fetchDiverProfileUseCase: FetchDiverProfileUseCase
     private let fetchDiverCollectionUseCase: DiverCollectionUseCase
     private let updateDiverMemoUseCase: UpdateDiverMemoUseCase
-    private let saveDiverMemoUseCase: SaveDiverMemoUseCase
     private let postUserBadgeUseCase: PostUserBadgeUseCase
 
     init(
@@ -45,7 +44,6 @@ final class DiverProfileViewModel: ViewModelable {
         fetchDiverProfileUseCase: FetchDiverProfileUseCase,
         fetchDIverCollectionUseCase: DiverCollectionUseCase,
         updateDiverMemoUseCase: UpdateDiverMemoUseCase,
-        saveDiverMemoUseCase: SaveDiverMemoUseCase,
         postUserBadgeUseCase: PostUserBadgeUseCase,
         diverId: String
     ) {
@@ -54,7 +52,6 @@ final class DiverProfileViewModel: ViewModelable {
         self.fetchDiverProfileUseCase = fetchDiverProfileUseCase
         self.fetchDiverCollectionUseCase = fetchDIverCollectionUseCase
         self.updateDiverMemoUseCase = updateDiverMemoUseCase
-        self.saveDiverMemoUseCase = saveDiverMemoUseCase
         self.postUserBadgeUseCase = postUserBadgeUseCase
         self.state.diverId = diverId
     }
@@ -120,7 +117,7 @@ final class DiverProfileViewModel: ViewModelable {
     }
 
     private func createDiverMemo() async {
-        let createResult = await saveDiverMemoUseCase.executeSaveDiverMemoUseCase(
+        let createResult = await updateDiverMemoUseCase.executeUpdateDiverMemoUseCase(
             foundUserId: state.diverId,
             memo: memo
         )

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/ViewModel/DiverSearchingViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/DiverSearchingScene/ViewModel/DiverSearchingViewModel.swift
@@ -34,6 +34,7 @@ final class DiverSearchingViewModel: ViewModelable {
         self.diverProfile = DiverProfile.mockData
         self.fetchDiverProfileUseCase = fetchDiverProfileUseCase
         self.fetchRefreshTokenUseCase = fetchRefreshTokenUseCase
+        dataTransferManager.currentMode = .diverSearch
     }
     
     func action(_ action: Action) {


### PR DESCRIPTION
## 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] 다이버 탐색 플로우 양쪽 모두 대화 완료시 저장되도록 변경
- [x] 새로 추가된 다이버 존재 시 플래그 저장
- [x] 양쪽 대화 완료를 확인하는 로직과 화면 추가

## 📌 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
### 대화 완료 대기 화면

<img width="341" alt="Screenshot 2025-05-18 at 9 30 25 AM" src="https://github.com/user-attachments/assets/d3ff9dec-ed19-4da0-bd12-698534e86cfb" />

대화 완료 이후 위 화면에서 상대 다이버의 대화 완료를 기다립니다.
상대방이 대화 완료하면 자동 감지되어 다이버카드 화면으로 넘어갑니다.
이 시점에(감지된) 새로운 다이버 정보를 collection에 추가합니다.
