### PR TITLE
[Fix] 회원 탈퇴 기능 수정 및 사용자 인증 토큰 초기화 처리

### DIFF
--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -9,8 +9,7 @@ struct DiverBookIOSApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationStack(path: self.$coordinator.path) {
-//                OnboardingView(coordinator: self.coordinator)
-                LoginView(nickname: "Henry", coordinator: self.coordinator)
+                OnboardingView(coordinator: self.coordinator)
                     .toolbar(.hidden, for: .navigationBar)
                     .navigationDestination(
                         for: Path.self,

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Application/DiverBookIOSApp.swift
@@ -9,7 +9,8 @@ struct DiverBookIOSApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationStack(path: self.$coordinator.path) {
-                OnboardingView(coordinator: self.coordinator)
+//                OnboardingView(coordinator: self.coordinator)
+                LoginView(nickname: "Henry", coordinator: self.coordinator)
                     .toolbar(.hidden, for: .navigationBar)
                     .navigationDestination(
                         for: Path.self,

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/UserDeactivateEndpoint.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Endpoints/UserDeactivateEndpoint.swift
@@ -8,13 +8,10 @@
 import Foundation
 
 enum UserDeactivateEndpoint: Endpoint {
-    case deactivate
+    case deactivate(refreshToken: String)
 
     var path: String {
-        switch self {
-        case .deactivate:
-            return "/api/users/me/deactivate"
-        }
+        return "/api/users/me/deactivate"
     }
 
     var method: RequestMethod {
@@ -26,22 +23,18 @@ enum UserDeactivateEndpoint: Endpoint {
     }
 
     var header: [String: String]? {
-        switch self {
-        default:
-            return [
-                "accept": "*/*",
-                "Content-Type": "application/json",
-                "Authorization":
-                    "\(UserToken.tokenType) \(UserToken.accessToken)",
-            ]
-        }
+        return [
+            "accept": "*/*",
+            "Content-Type": "application/json",
+            "Authorization":
+                "\(UserToken.tokenType) \(UserToken.accessToken)",
+        ]
     }
 
     var body: [String: String]? {
         switch self {
-        default:
-            return nil
+        case .deactivate(let refreshToken):
+            return ["refreshToken": refreshToken]
         }
     }
-
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/UserDeactivateService.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Network/Services/UserDeactivateService.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 final class UserDeactivateService: UserDeactivateServicable {
-    func deactivateUser() async -> Result<BaseResponse<DiverProfileResModel>, RequestError> {
+    func deactivateUser(refreshToken: String) async -> Result<BaseResponse<DiverProfileResModel>, RequestError> {
         return await request(
-            endpoint: UserDeactivateEndpoint.deactivate,
+            endpoint: UserDeactivateEndpoint.deactivate(refreshToken: refreshToken),
             responseModel: BaseResponse<DiverProfileResModel>.self
         )
     }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/DefaultUserDeactivateRepository.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/DefaultUserDeactivateRepository.swift
@@ -14,8 +14,8 @@ final class DefaultUserDeactivateRepository: UserDeactivateRepository {
         self.userDeactivateService = userDeactivateService
     }
 
-    func deactivateUser() async -> Result<DiverProfile, Error> {
-        let result = await userDeactivateService.deactivateUser()
+    func deactivateUser(refreshToken: String) async -> Result<DiverProfile, Error> {
+        let result = await userDeactivateService.deactivateUser(refreshToken: refreshToken)
         switch result {
         case .success(let response):
             if let data = response.data {

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/UserDeactivateServicable.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/Repositories/Interfaces/UserDeactivateServicable.swift
@@ -8,5 +8,7 @@
 import Foundation
 
 protocol UserDeactivateServicable: HTTPClient {
-    func deactivateUser() async -> Result<BaseResponse<DiverProfileResModel>, RequestError>
+    func deactivateUser(refreshToken: String) async -> Result<
+        BaseResponse<DiverProfileResModel>, RequestError
+    >
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Data/UserDefaults/UserToken.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Data/UserDefaults/UserToken.swift
@@ -28,3 +28,12 @@ extension UserToken {
         self.id = authInfo.id
     }
 }
+
+extension UserToken {
+    static func clear() {
+        self.accessToken = ""
+        self.refreshToken = ""
+        self.tokenType = ""
+        self.id = ""
+    }
+}

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/UserDeactivateRepository.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/Interfaces/Repositories/UserDeactivateRepository.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol UserDeactivateRepository {
-    func deactivateUser() async -> Result<DiverProfile, Error>
+    func deactivateUser(refreshToken: String) async -> Result<DiverProfile, Error>
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/DeactivateUserUseCase/DeactivateUserUseCase.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Domain/UseCases/DeactivateUserUseCase/DeactivateUserUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol DeactivateUserUseCase {
-    func execute() async -> Result<DiverProfile, Error>
+    func execute(refreshToken: String) async -> Result<DiverProfile, Error>
 }
 
 final class DefaultDeactivateUserUseCase: DeactivateUserUseCase {
@@ -18,7 +18,7 @@ final class DefaultDeactivateUserUseCase: DeactivateUserUseCase {
         self.repository = repository
     }
 
-    func execute() async -> Result<DiverProfile, Error> {
-        return await repository.deactivateUser()
+    func execute(refreshToken: String) async -> Result<DiverProfile, Error> {
+        return await repository.deactivateUser(refreshToken: refreshToken)
     }
 }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/ViewModel/SystemSettingViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/ViewModel/SystemSettingViewModel.swift
@@ -60,6 +60,7 @@ final class SystemSettingViewModel: ViewModelable {
                 switch result {
                 case .success:
                     print("✅ 회원 탈퇴 성공")
+                    UserToken.clear()
                     await MainActor.run {
                         coordinator.path = [.splash]
                     }

--- a/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/ViewModel/SystemSettingViewModel.swift
+++ b/DiverBook_iOS/DiverBook_iOS/Sources/Presentation/SystemSettingScene/ViewModel/SystemSettingViewModel.swift
@@ -54,7 +54,9 @@ final class SystemSettingViewModel: ViewModelable {
         case .confirmWithdraw:
             state.showWithdrawAlert = false
             Task {
-                let result = await deactivateUserUseCase.execute()
+                let result = await deactivateUserUseCase.execute(
+                    refreshToken: UserToken.refreshToken
+                )
                 switch result {
                 case .success:
                     print("✅ 회원 탈퇴 성공")


### PR DESCRIPTION
## 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- 회원 탈퇴 API 변경사항 반영 (refreshToken body 포함)
- UserDeactivateEndpoint에 refreshToken 전달 구조로 수정
- SystemSettingViewModel에서 탈퇴 성공 시 UserToken.clear() 호출 추가
- SplashView 진입 시에도 로그인 상태가 아닌 것으로 처리되도록 토큰 초기화 처리

## 📌 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
### 특이 사항 1
- 탈퇴 후 accessToken, refreshToken, tokenType, id가 UserDefaults에 남아 있어 SplashView에서 로그인된 상태로 인식되던 문제를 UserToken.clear()로 해결했습니다.


https://github.com/user-attachments/assets/1392a865-b875-47f1-ae67-4acf665956e0

